### PR TITLE
Components 네트워킹

### DIFF
--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A53241E8253D9B3D004FEF3C /* EntryImageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53241E7253D9B3D004FEF3C /* EntryImageUseCaseTests.swift */; };
 		A53241F1253DAF8F004FEF3C /* UseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53241F0253DAF8F004FEF3C /* UseCaseError.swift */; };
 		A532D2D72505094A009361DC /* CustomizeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A532D2D62505094A009361DC /* CustomizeViewController.swift */; };
+		A534809725481E40001C039E /* CategoryComponentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A534809625481E40001C039E /* CategoryComponentManager.swift */; };
 		A5434F0B2538238D00782F2C /* ComponentCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5434F0A2538238D00782F2C /* ComponentCollectionView.swift */; };
 		A5511436253B22040068A4D2 /* ColorSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5511435253B22040068A4D2 /* ColorSelectViewController.swift */; };
 		A551143E253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A551143D253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift */; };
@@ -79,6 +80,7 @@
 		A53241E7253D9B3D004FEF3C /* EntryImageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryImageUseCaseTests.swift; sourceTree = "<group>"; };
 		A53241F0253DAF8F004FEF3C /* UseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseError.swift; sourceTree = "<group>"; };
 		A532D2D62505094A009361DC /* CustomizeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeViewController.swift; sourceTree = "<group>"; };
+		A534809625481E40001C039E /* CategoryComponentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryComponentManager.swift; sourceTree = "<group>"; };
 		A5434F0A2538238D00782F2C /* ComponentCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentCollectionView.swift; sourceTree = "<group>"; };
 		A5511435253B22040068A4D2 /* ColorSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectViewController.swift; sourceTree = "<group>"; };
 		A551143D253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 			children = (
 				A5EEC109253F5FC60048A13D /* Category.swift */,
 				A5AEDF4C253FCDA10083F3D2 /* Component.swift */,
+				A534809625481E40001C039E /* CategoryComponentManager.swift */,
 			);
 			path = CustomizeView;
 			sourceTree = "<group>";
@@ -553,6 +556,7 @@
 				A52D7065253D51770071613B /* NetworkManageable.swift in Sources */,
 				A5EDB61E2532220C00E6078B /* ComponentCollectionViewDataSource.swift in Sources */,
 				A5EEC10A253F5FC60048A13D /* Category.swift in Sources */,
+				A534809725481E40001C039E /* CategoryComponentManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A53241F1253DAF8F004FEF3C /* UseCaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53241F0253DAF8F004FEF3C /* UseCaseError.swift */; };
 		A532D2D72505094A009361DC /* CustomizeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A532D2D62505094A009361DC /* CustomizeViewController.swift */; };
 		A534809725481E40001C039E /* CategoryComponentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A534809625481E40001C039E /* CategoryComponentManager.swift */; };
+		A534809B25481E53001C039E /* CategoryComponentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A534809A25481E53001C039E /* CategoryComponentManagerTests.swift */; };
 		A5434F0B2538238D00782F2C /* ComponentCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5434F0A2538238D00782F2C /* ComponentCollectionView.swift */; };
 		A5511436253B22040068A4D2 /* ColorSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5511435253B22040068A4D2 /* ColorSelectViewController.swift */; };
 		A551143E253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A551143D253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift */; };
@@ -81,6 +82,7 @@
 		A53241F0253DAF8F004FEF3C /* UseCaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseError.swift; sourceTree = "<group>"; };
 		A532D2D62505094A009361DC /* CustomizeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeViewController.swift; sourceTree = "<group>"; };
 		A534809625481E40001C039E /* CategoryComponentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryComponentManager.swift; sourceTree = "<group>"; };
+		A534809A25481E53001C039E /* CategoryComponentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryComponentManagerTests.swift; sourceTree = "<group>"; };
 		A5434F0A2538238D00782F2C /* ComponentCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentCollectionView.swift; sourceTree = "<group>"; };
 		A5511435253B22040068A4D2 /* ColorSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectViewController.swift; sourceTree = "<group>"; };
 		A551143D253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 				A5844A9B253D67B600A24256 /* EndPointTests.swift */,
 				A5AEDF55253FF3660083F3D2 /* ComponentsTests.swift */,
 				A521F020254557BB0002031A /* CategoriesTests.swift */,
+				A534809A25481E53001C039E /* CategoryComponentManagerTests.swift */,
 			);
 			path = IDIllustTests;
 			sourceTree = "<group>";
@@ -567,6 +570,7 @@
 				A5C8D8EF253D5B94002ADD9E /* NetworkTests.swift in Sources */,
 				A521F0142543FEA00002031A /* ComponentsUseCaseTests.swift in Sources */,
 				A53241E8253D9B3D004FEF3C /* EntryImageUseCaseTests.swift in Sources */,
+				A534809B25481E53001C039E /* CategoryComponentManagerTests.swift in Sources */,
 				A5844A9C253D67B600A24256 /* EndPointTests.swift in Sources */,
 				A5EEC119253F64620048A13D /* CategoryUseCaseTests.swift in Sources */,
 				A521F0082543DD8B0002031A /* MockNetworkManagers.swift in Sources */,

--- a/iOS/IDIllust/IDIllust/CustomizeView/CategoryCollectionView/CategoryCollectionViewDataSource.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CategoryCollectionView/CategoryCollectionViewDataSource.swift
@@ -24,11 +24,7 @@ final class CategoryCollectionViewDataSource: NSObject, UICollectionViewDataSour
         
         cell.imageView.kf.indicatorType = .activity
         cell.imageView.kf.setImage(with: URL(string: url))
-        
-        if collectionView.indexPathsForSelectedItems == nil && indexPath.row == 0 {
-            cell.isSelected = true
-        }
-        
+
         return cell
     }
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionView.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionView.swift
@@ -13,11 +13,23 @@ final class ComponentCollectionView: UICollectionView {
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)
         registGesture()
+        setUpCollectionView()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         registGesture()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setSquarCell(factor: frame.width, divide: 3)
+        setSpacing(line: 0, interItem: 0)
+    }
+    
+    private func setUpCollectionView() {
+        translatesAutoresizingMaskIntoConstraints = false
+        register(ComponentCollectionViewCell.self, forCellWithReuseIdentifier: ComponentCollectionViewCell.identifier)
     }
     
     private func registGesture() {

--- a/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewCell.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewCell.swift
@@ -50,7 +50,7 @@ final class ComponentCollectionViewCell: UICollectionViewCell {
         imageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
         imageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
         imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).isActive = true
-        imageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.5).isActive = true
+        imageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.6).isActive = true
     }
     
     private func setSelectedImageViewLayout() {

--- a/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewDataSource.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewDataSource.swift
@@ -6,17 +6,24 @@
 //  Copyright © 2020 신한섭. All rights reserved.
 //
 
+import Kingfisher
 import UIKit
 
 final class ComponentCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     
+    var components: Components?
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10
+        return components?.count ?? 10
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ComponentCollectionViewCell.identifier, for: indexPath) as? ComponentCollectionViewCell else { return UICollectionViewCell() }
-        cell.imageView.image = #imageLiteral(resourceName: "ic_hair_1")
+        guard let url = components?.component(of: indexPath.item)?.url else { return cell }
+        
+        cell.imageView.kf.indicatorType = .activity
+        cell.imageView.kf.setImage(with: URL(string: url))
+        
         return cell
     }
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -130,7 +130,12 @@ final class CustomizeViewController: UIViewController {
         
         if selected.item != item {
             categoryCollectionView.selectItem(at: IndexPath(item: item, section: 0), animated: true, scrollPosition: .centeredHorizontally)
-            setComponentsUseCase(categories?.category(of: item)?.id)
+            
+            guard let categoryId = categoryComponentManager.category(of: item)?.id else { return }
+            guard categoryComponentManager.isExistComponents(with: categoryId) else {
+                setComponentsUseCase(categoryComponentManager.category(of: item)?.id)
+                return
+            }
         }
     }
     

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -21,7 +21,9 @@ final class CustomizeViewController: UIViewController {
     private var categories: Categories? {
         didSet {
             categoryCollectionViewDataSource.model = categories
-            reloadCategoryCollectionView()
+            DispatchQueue.main.async { [weak self] in
+                self?.setCategoryCollectionView()
+            }
         }
     }
     
@@ -29,8 +31,7 @@ final class CustomizeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         addObserves()
-        setCategoryCollectionView()
-        categoriesUseCase()
+        setCategoriesUseCase()
         setComponentCollectionViews()
         componentScrollView.delegate = self
     }
@@ -39,6 +40,7 @@ final class CustomizeViewController: UIViewController {
     private func setCategoryCollectionView() {
         categoryCollectionView.setSquarCell(factor: categoryCollectionView.frame.height)
         categoryCollectionView.dataSource = categoryCollectionViewDataSource
+        categoryCollectionView.selectItem(at: IndexPath(item: 0, section: 0), animated: false, scrollPosition: .left)
     }
     
     private func setComponentCollectionViews() {
@@ -74,15 +76,14 @@ final class CustomizeViewController: UIViewController {
                                                object: nil)
     }
     
-    private func categoriesUseCase() {
-        CategoriesUseCase()
-            .retrieveCategories(networkManager: NetworkManager(),
-                                failureHandler: { _ in
-                                    // Todo: UseCaseError에 따른 예외 처리
-                                },
-                                successHandler: { [weak self] in
-                                    self?.categories = $0
-                                })
+    private func setCategoriesUseCase() {
+        CategoriesUseCase().retrieveCategories(networkManager: NetworkManager(),
+                                               failureHandler: { _ in
+                                                // Todo: UseCaseError에 따른 예외 처리
+                                               },
+                                               successHandler: { [weak self] in
+                                                self?.categories = $0
+                                               })
     }
     
     private func reloadCategoryCollectionView() {
@@ -138,7 +139,7 @@ final class CustomizeViewController: UIViewController {
         guard let point = notification.userInfo?["point"] as? CGPoint else { return }
         guard let selected = categoryCollectionView.indexPathsForSelectedItems?.first?.item else { return }
         var convertedPoint = convert(point: point, to: [componentCollectionViews[selected], componentsStackView, view])
-    
+        
         setColorSelectViewSize()
         correct(point: &convertedPoint)
         

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -140,13 +140,17 @@ final class CustomizeViewController: UIViewController {
     }
     
     @objc func scrollComponentScrollView() {
-        guard let selected = categoryCollectionView.indexPathsForSelectedItems?.first else { return }
-        let willX = selected.item * Int(view.frame.width)
+        guard let index = categoryCollectionView.indexPathsForSelectedItems?.first?.item else { return }
+        let willX = index * Int(view.frame.width)
         let currentX = Int(componentScrollView.contentOffset.x)
         
         if willX != currentX {
-            setComponentsUseCase(categories?.category(of: selected.item)?.id)
             componentScrollView.setContentOffset(CGPoint(x: willX, y: 0), animated: true)
+            guard let categoryId = categoryComponentManager.category(of: index)?.id else { return }
+            guard categoryComponentManager.isExistComponents(with: categoryId) else {
+                setComponentsUseCase(categoryComponentManager.category(of: index)?.id)
+                return
+            }
         }
     }
     

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -101,13 +101,6 @@ final class CustomizeViewController: UIViewController {
                                                })
     }
     
-    private func reloadCategoryCollectionView() {
-        DispatchQueue.main.async { [weak self] in
-            self?.categoryCollectionView.reloadData()
-            self?.categoryCollectionView.selectItem(at: IndexPath(item: 0, section: 0), animated: true, scrollPosition: .left)
-        }
-    }
-    
     private func convert(point: CGPoint, to views: [UIView]) -> CGPoint {
         var converted: CGPoint = point
         for index in 0..<views.count - 1 {

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -40,13 +40,9 @@ final class CustomizeViewController: UIViewController {
             let dataSource = ComponentCollectionViewDataSource()
             componentCollectionViewDataSources.append(dataSource)
             let collectionView = ComponentCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-            collectionView.translatesAutoresizingMaskIntoConstraints = false
-            collectionView.register(ComponentCollectionViewCell.self, forCellWithReuseIdentifier: ComponentCollectionViewCell.identifier)
             componentCollectionViews.append(collectionView)
             componentsStackView.addArrangedSubview(collectionView)
             collectionView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1).isActive = true
-            collectionView.setSquarCell(factor: view.frame.width, divide: 3)
-            collectionView.setSpacing(line: 0, interItem: 0)
             collectionView.dataSource = dataSource
             collectionView.backgroundColor = .systemBackground
         }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -80,6 +80,10 @@ final class CustomizeViewController: UIViewController {
                                                selector: #selector(hideColorSelectView),
                                                name: .LongPressEnded,
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(reloadComponentsCollectionView),
+                                               name: .ComponentsAppended,
+                                               object: nil)
     }
     
     private func setCategoriesUseCase() {
@@ -171,6 +175,14 @@ final class CustomizeViewController: UIViewController {
     
     @objc func hideColorSelectView() {
         colorSelectView.isHidden = true
+    }
+    
+    @objc func reloadComponentsCollectionView() {
+        DispatchQueue.main.async { [weak self] in
+            guard let selected = self?.categoryCollectionView.indexPathsForSelectedItems?.first?.item else { return }
+            self?.componentCollectionViewDataSources[selected].components = self?.componentsManager.components(of: selected)
+            self?.componentCollectionViews[selected].reloadData()
+        }
     }
 }
 

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -107,7 +107,7 @@ final class CustomizeViewController: UIViewController {
     private func reloadCategoryCollectionView() {
         DispatchQueue.main.async { [weak self] in
             self?.categoryCollectionView.reloadData()
-            self?.categoryCollectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: true, scrollPosition: .left)
+            self?.categoryCollectionView.selectItem(at: IndexPath(item: 0, section: 0), animated: true, scrollPosition: .left)
         }
     }
     
@@ -135,20 +135,22 @@ final class CustomizeViewController: UIViewController {
     
     // MARK: @objc
     @objc func scrollCategoryCollectionView(_ notification: Notification) {
-        guard let row = notification.userInfo?["row"] as? Int else { return }
-        guard let selected = categoryCollectionView.indexPathsForSelectedItems else { return }
+        guard let item = notification.userInfo?["item"] as? Int else { return }
+        guard let selected = categoryCollectionView.indexPathsForSelectedItems?.first else { return }
         
-        if selected[0].row != row {
-            categoryCollectionView.selectItem(at: IndexPath(row: row, section: 0), animated: true, scrollPosition: .centeredHorizontally)
+        if selected.item != item {
+            categoryCollectionView.selectItem(at: IndexPath(item: item, section: 0), animated: true, scrollPosition: .centeredHorizontally)
+            setComponentsUseCase(categories?.category(of: item)?.id)
         }
     }
     
     @objc func scrollComponentScrollView() {
-        guard let selected = categoryCollectionView.indexPathsForSelectedItems else { return }
-        let willX = selected[0].row * Int(view.frame.width)
+        guard let selected = categoryCollectionView.indexPathsForSelectedItems?.first else { return }
+        let willX = selected.item * Int(view.frame.width)
         let currentX = Int(componentScrollView.contentOffset.x)
         
         if willX != currentX {
+            setComponentsUseCase(categories?.category(of: selected.item)?.id)
             componentScrollView.setContentOffset(CGPoint(x: willX, y: 0), animated: true)
         }
     }
@@ -181,7 +183,7 @@ extension CustomizeViewController: UIScrollViewDelegate {
         if (curX.truncatingRemainder(dividingBy: width)) == 0 {
             NotificationCenter.default.post(name: .ComponentScrollViewSrcolled,
                                             object: nil,
-                                            userInfo: ["row": index])
+                                            userInfo: ["item": index])
         }
     }
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ComponentsUseCase.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ComponentsUseCase.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-struct ComponentsUseCase<T>: RetrieveModelFromServer where T: Codable {
+struct ComponentsUseCase: RetrieveModelFromServer {
     
-    typealias Model = T
+    typealias Model = Components
     
     @discardableResult
     func retrieveComponents(networkManager: NetworkManageable, categoryId: Int, failurehandler: @escaping (UseCaseError) -> Void = { _ in }, successHandler: @escaping (Model) -> Void) -> URLSessionDataTask? {

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/Category.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/Category.swift
@@ -11,6 +11,9 @@ import Foundation
 struct Categories: Decodable {
     
     let categories: [Category]
+    var count: Int {
+        return categories.count
+    }
     
     func category(of index: Int) -> Category? {
         guard !isExceed(index: index) else { return nil }
@@ -28,4 +31,8 @@ struct Category: Decodable {
     let id: Int
     let name: String
     let url: String
+}
+
+extension Notification.Name {
+    static let CategoryChanged = Notification.Name("categoryChanged")
 }

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/CategoryComponentManager.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/CategoryComponentManager.swift
@@ -1,0 +1,49 @@
+//
+//  CategoryComponentManager.swift
+//  IDIllust
+//
+//  Created by 신한섭 on 2020/10/27.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import Foundation
+
+final class CategoryComponentManager {
+    
+    private var componentsOfCategoryId: [Int: Components] = [Int: Components]()
+    private(set) var categories: Categories?
+    var categoryCount: Int? {
+        return categories?.count
+    }
+    
+    func insert(categories: Categories) {
+        self.categories = categories
+        NotificationCenter.default.post(name: .CategoryChanged,
+                                        object: nil)
+    }
+    
+    func insert(components: Components, by categoryId: Int) {
+        componentsOfCategoryId[categoryId] = components
+        
+        NotificationCenter.default.post(name: .ComponentsAppended,
+                                        object: nil)
+    }
+    
+    func category(of index: Int) -> Category? {
+        categories?.category(of: index)
+    }
+    
+    func components(of categroyId: Int) -> Components? {
+        return componentsOfCategoryId[categroyId]
+    }
+    
+    func componentsCount(of categoryId: Int) -> Int? {
+        return componentsOfCategoryId[categoryId]?.count
+    }
+    
+    func isExistComponents(with categoryId: Int) -> Bool {
+        guard componentsOfCategoryId[categoryId] != nil else { return false }
+        
+        return true
+    }
+}

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
@@ -21,6 +21,9 @@ final class ComponentsManager {
     
     func append(_ components: Components) {
         componentsList.append(components)
+        
+        NotificationCenter.default.post(name: .ComponentsAppended,
+                                        object: nil)
     }
     
     func insert(_ components: Components, at index: Int) {
@@ -59,6 +62,10 @@ struct Components: Decodable {
     
     let components: [Component]
     
+    var count: Int {
+        return components.count
+    }
+    
     func component(of index: Int) -> Component? {
         guard !isExceed(index: index) else { return nil }
         
@@ -81,4 +88,8 @@ struct Component: Decodable {
         case name
         case url = "thumb_url"
     }
+}
+
+extension Notification.Name {
+    static let ComponentsAppended = Notification.Name("componentsAppended")
 }

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
@@ -8,56 +8,6 @@
 
 import Foundation
 
-final class ComponentsManager {
-    
-    private var componentsList: [Components]
-    var count: Int {
-        return componentsList.count
-    }
-    
-    init(_ components: [Components] = [Components]()) {
-        self.componentsList = components
-    }
-    
-    func append(_ components: Components) {
-        componentsList.append(components)
-        
-        NotificationCenter.default.post(name: .ComponentsAppended,
-                                        object: nil)
-    }
-    
-    func insert(_ components: Components, at index: Int) {
-        guard !isExceed(index: index) else { return }
-        
-        componentsList.insert(components, at: index)
-    }
-    
-    func components(of index: Int) -> Components? {
-        guard !isExceed(index: index) else { return nil }
-        
-        return componentsList[index]
-    }
-    
-    func component(of indexPath: IndexPath) -> Component? {
-        guard !isExceed(indexPath: indexPath) else { return nil }
-        
-        return componentsList[indexPath.section].component(of: indexPath.item)
-    }
-    
-    private func isExceed(index: Int) -> Bool {
-        guard index < componentsList.count else { return true }
-        
-        return false
-    }
-    
-    private func isExceed(indexPath: IndexPath) -> Bool {
-        guard !isExceed(index: indexPath.section) else { return true }
-        guard componentsList[indexPath.section].component(of: indexPath.item) != nil else { return true }
-        
-        return false
-    }
-}
-
 struct Components: Decodable {
     
     let components: [Component]

--- a/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
@@ -1,0 +1,66 @@
+//
+//  CategoryComponentManagerTests.swift
+//  IDIllustTests
+//
+//  Created by 신한섭 on 2020/10/27.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+@testable import IDIllust
+import XCTest
+
+final class CategoryComponentManagerTests: XCTestCase {
+    
+    private var categoryComponentManager: CategoryComponentManager!
+    private var category: IDIllust.Category!
+    private var categories: Categories!
+    private var component: Component!
+    private var components: Components!
+
+    override func setUpWithError() throws {
+        categoryComponentManager = CategoryComponentManager()
+        category = IDIllust.Category(id: 1, name: "category", url: "url")
+        categories = Categories(categories: [category])
+        component = Component(id: 1, name: "component", url: "url")
+        components = Components(components: [component])
+    }
+    
+    func testInsertCategories() {
+        categoryComponentManager.insert(categories: categories)
+        let inserted = categoryComponentManager.categories
+        XCTAssertEqual(categories, inserted)
+    }
+    
+    func testInsertComponents() {
+        categoryComponentManager.insert(categories: categories)
+        categoryComponentManager.insert(components: components, by: category.id)
+        let inserted = categoryComponentManager.components(of: category.id)
+        XCTAssertEqual(components, inserted)
+    }
+    
+    func testCategory() {
+        categoryComponentManager.insert(categories: categories)
+        let inserted = categoryComponentManager.category(of: 0)
+        XCTAssertEqual(category, inserted)
+    }
+    
+    func testCategoryCount() {
+        XCTAssertNil(categoryComponentManager.categoryCount)
+        categoryComponentManager.insert(categories: categories)
+        XCTAssertEqual(categoryComponentManager.categoryCount, 1)
+    }
+    
+    func testComponentsCount() {
+        XCTAssertNil(categoryComponentManager.componentsCount(of: category.id))
+        categoryComponentManager.insert(categories: categories)
+        categoryComponentManager.insert(components: components, by: category.id)
+        XCTAssertEqual(categoryComponentManager.componentsCount(of: category.id), 1)
+    }
+    
+    func testIsExistComponents() {
+        categoryComponentManager.insert(categories: categories)
+        categoryComponentManager.insert(components: components, by: category.id)
+        XCTAssertTrue(categoryComponentManager.isExistComponents(with: category.id))
+        XCTAssertFalse(categoryComponentManager.isExistComponents(with: -1))
+    }
+}

--- a/iOS/IDIllust/IDIllustTests/ComponentsTests.swift
+++ b/iOS/IDIllust/IDIllustTests/ComponentsTests.swift
@@ -12,18 +12,12 @@ import XCTest
 final class ComponentsTests: XCTestCase {
     
     private var component: Component!
-    private var anotherComponent: Component!
     private var components: Components!
-    private var anotherComponents: Components!
-    private var componentsManger: ComponentsManager!
     
     override func setUp() {
         super.setUp()
         component = Component(id: 1, name: "test", url: "url")
-        anotherComponent = Component(id: 2, name: "test2", url: "url2")
         components = Components(components: [component])
-        anotherComponents = Components(components: [anotherComponent])
-        componentsManger = ComponentsManager([components])
     }
     
     func testComponentsGetComponent() {
@@ -31,28 +25,8 @@ final class ComponentsTests: XCTestCase {
         XCTAssertNil(components.component(of: 1))
     }
     
-    func testComponentsManagerGetComponents() {
-        XCTAssertEqual(componentsManger.components(of: 0), components)
-        XCTAssertNil(componentsManger.components(of: 1))
-    }
-    
-    func testComponentsManagerGetComponent() {
-        XCTAssertEqual(componentsManger.component(of: IndexPath(item: 0, section: 0)), component)
-        XCTAssertNil(componentsManger.component(of: IndexPath(item: 0, section: 1)))
-        XCTAssertNil(componentsManger.component(of: IndexPath(item: 1, section: 0)))
-    }
-    
-    func testComponentsManagerAppend() {
-        componentsManger.append(anotherComponents)
-        XCTAssertEqual(2, componentsManger.count)
-        XCTAssertEqual(componentsManger.components(of: 1), anotherComponents)
-    }
-    
-    func testComponentsManagerInsert() {
-        componentsManger.insert(anotherComponents, at: 1)
-        componentsManger.insert(anotherComponents, at: 0)
-        XCTAssertEqual(2, componentsManger.count)
-        XCTAssertEqual(componentsManger.components(of: 0), anotherComponents)
+    func testCount() {
+        XCTAssertEqual(components.count, 1)
     }
 }
 


### PR DESCRIPTION
- CategroyId에 해당하는 Components를 서버에서 받아오도록 구현했습니다.
- 이를 위해 CategoryId를 key로 가지고 Components를 value로 가지고 관리하는 CategoryComponentManager 클래스를 만들었습니다.
- 기존에 사용하던 ComponentsManger와 Categories는 위 객체로 대체되었습니다.
- CategoryCollectionView를 선택하거나, ComponentsScrollView를 스크롤해서 현재 선택된 CategoryId가 바뀌면 해당 CategoryId에 해당하는 Components를 서버에서 받아오도록 했습니다.
- 이미 로컬에 CategoryId에 해당하는 Components가 있는 경우는 서버에서 받아오지 않습니다.
- 아직 동시성처리는 하지 않았습니다만, 서로 다른 collectionView와 서로 다른 datasource로 처리했다보니 아직은 이슈가 없습니다(ex: UI update중에 indexPath가 바뀌는 경우).