### PR TITLE
Thumbnail netwokring

### DIFF
--- a/iOS/IDIllust/.swiftlint.yml
+++ b/iOS/IDIllust/.swiftlint.yml
@@ -4,6 +4,7 @@ disabled_rules:
 - trailing_whitespace
 - closure_end_indentation
 - multiline_arguments_brackets
+- empty_enum_arguments
 
 opt_in_rules:
 - closure_spacing

--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		A506C99A254272D100E6BCE6 /* RetrieveModelFromServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A506C999254272D100E6BCE6 /* RetrieveModelFromServer.swift */; };
 		A506C9A12542758200E6BCE6 /* RetrieveModelFromServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A506C9A02542758200E6BCE6 /* RetrieveModelFromServerTests.swift */; };
 		A50BA707254B374D00985306 /* SelectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50BA706254B374D00985306 /* SelectionManager.swift */; };
+		A50BA70D254B44F200985306 /* SelectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50BA70C254B44F200985306 /* SelectionManagerTests.swift */; };
+		A50BA711254B45D800985306 /* CurrentSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50BA710254B45D800985306 /* CurrentSelection.swift */; };
 		A50E3A9B254960750004DEA7 /* ComponentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50E3A9A254960750004DEA7 /* ComponentColor.swift */; };
 		A50E3AA2254962700004DEA7 /* ComponentColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50E3AA1254962700004DEA7 /* ComponentColors.swift */; };
 		A50E3AA82549660A0004DEA7 /* ModelManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50E3AA72549660A0004DEA7 /* ModelManageable.swift */; };
@@ -83,6 +85,8 @@
 		A506C999254272D100E6BCE6 /* RetrieveModelFromServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveModelFromServer.swift; sourceTree = "<group>"; };
 		A506C9A02542758200E6BCE6 /* RetrieveModelFromServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveModelFromServerTests.swift; sourceTree = "<group>"; };
 		A50BA706254B374D00985306 /* SelectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionManager.swift; sourceTree = "<group>"; };
+		A50BA70C254B44F200985306 /* SelectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionManagerTests.swift; sourceTree = "<group>"; };
+		A50BA710254B45D800985306 /* CurrentSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentSelection.swift; sourceTree = "<group>"; };
 		A50E3A9A254960750004DEA7 /* ComponentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentColor.swift; sourceTree = "<group>"; };
 		A50E3AA1254962700004DEA7 /* ComponentColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentColors.swift; sourceTree = "<group>"; };
 		A50E3AA72549660A0004DEA7 /* ModelManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManageable.swift; sourceTree = "<group>"; };
@@ -200,6 +204,7 @@
 				A521F020254557BB0002031A /* Categories.swift */,
 				A50E3AA1254962700004DEA7 /* ComponentColors.swift */,
 				A5B67F6F254B1E72005F098C /* Thumbnail.swift */,
+				A50BA710254B45D800985306 /* CurrentSelection.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -379,6 +384,7 @@
 				A521F0072543DD8B0002031A /* MockNetworkManagers.swift */,
 				A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */,
 				A5844A9B253D67B600A24256 /* EndPointTests.swift */,
+				A50BA70C254B44F200985306 /* SelectionManagerTests.swift */,
 			);
 			path = IDIllustTests;
 			sourceTree = "<group>";
@@ -630,12 +636,14 @@
 				A5C8D8EF253D5B94002ADD9E /* NetworkTests.swift in Sources */,
 				A521F0142543FEA00002031A /* ComponentsUseCaseTests.swift in Sources */,
 				A53241E8253D9B3D004FEF3C /* EntryImageUseCaseTests.swift in Sources */,
+				A50BA70D254B44F200985306 /* SelectionManagerTests.swift in Sources */,
 				A50E3AA2254962700004DEA7 /* ComponentColors.swift in Sources */,
 				A534809B25481E53001C039E /* CategoryComponentManagerTests.swift in Sources */,
 				A5844A9C253D67B600A24256 /* EndPointTests.swift in Sources */,
 				A5B67F70254B1E72005F098C /* Thumbnail.swift in Sources */,
 				A50E3AAC254972AD0004DEA7 /* ModelManageableTests.swift in Sources */,
 				A5EEC119253F64620048A13D /* CategoryUseCaseTests.swift in Sources */,
+				A50BA711254B45D800985306 /* CurrentSelection.swift in Sources */,
 				A521F0082543DD8B0002031A /* MockNetworkManagers.swift in Sources */,
 				A506C9A12542758200E6BCE6 /* RetrieveModelFromServerTests.swift in Sources */,
 				A5AEDF56253FF3670083F3D2 /* Components.swift in Sources */,

--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A506C98C25426CD100E6BCE6 /* ComponentsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A506C98B25426CD100E6BCE6 /* ComponentsUseCase.swift */; };
 		A506C99A254272D100E6BCE6 /* RetrieveModelFromServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A506C999254272D100E6BCE6 /* RetrieveModelFromServer.swift */; };
 		A506C9A12542758200E6BCE6 /* RetrieveModelFromServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A506C9A02542758200E6BCE6 /* RetrieveModelFromServerTests.swift */; };
+		A50BA707254B374D00985306 /* SelectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50BA706254B374D00985306 /* SelectionManager.swift */; };
 		A50E3A9B254960750004DEA7 /* ComponentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50E3A9A254960750004DEA7 /* ComponentColor.swift */; };
 		A50E3AA2254962700004DEA7 /* ComponentColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50E3AA1254962700004DEA7 /* ComponentColors.swift */; };
 		A50E3AA82549660A0004DEA7 /* ModelManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50E3AA72549660A0004DEA7 /* ModelManageable.swift */; };
@@ -81,6 +82,7 @@
 		A506C98B25426CD100E6BCE6 /* ComponentsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsUseCase.swift; sourceTree = "<group>"; };
 		A506C999254272D100E6BCE6 /* RetrieveModelFromServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveModelFromServer.swift; sourceTree = "<group>"; };
 		A506C9A02542758200E6BCE6 /* RetrieveModelFromServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveModelFromServerTests.swift; sourceTree = "<group>"; };
+		A50BA706254B374D00985306 /* SelectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionManager.swift; sourceTree = "<group>"; };
 		A50E3A9A254960750004DEA7 /* ComponentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentColor.swift; sourceTree = "<group>"; };
 		A50E3AA1254962700004DEA7 /* ComponentColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentColors.swift; sourceTree = "<group>"; };
 		A50E3AA72549660A0004DEA7 /* ModelManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManageable.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 				A5EDB6232532226A00E6078B /* ComponentCollectionView */,
 				A5EDB6222532225A00E6078B /* CategoryCollectionView */,
 				A532D2D62505094A009361DC /* CustomizeViewController.swift */,
+				A50BA706254B374D00985306 /* SelectionManager.swift */,
 			);
 			path = CustomizeView;
 			sourceTree = "<group>";
@@ -604,6 +607,7 @@
 				A5511436253B22040068A4D2 /* ColorSelectViewController.swift in Sources */,
 				A5511444253B2E880068A4D2 /* UIDevice.swift in Sources */,
 				A551143E253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift in Sources */,
+				A50BA707254B374D00985306 /* SelectionManager.swift in Sources */,
 				A5FB9608254ADD9B00FF4C51 /* CGPoint.swift in Sources */,
 				A5F893442500A8C7002258EA /* SceneDelegate.swift in Sources */,
 				A5B67F7D254B2F8F005F098C /* ComponentCollectionViewEvent.swift in Sources */,

--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		A5B67F63254B1C8B005F098C /* ThumbnailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F62254B1C8B005F098C /* ThumbnailUseCase.swift */; };
 		A5B67F6C254B1E32005F098C /* ThumbnailUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F6B254B1E32005F098C /* ThumbnailUseCaseTests.swift */; };
 		A5B67F70254B1E72005F098C /* Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F6F254B1E72005F098C /* Thumbnail.swift */; };
+		A5B67F79254B2F4B005F098C /* ComponentCollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F78254B2F4B005F098C /* ComponentCollectionViewDelegate.swift */; };
 		A5B67F7D254B2F8F005F098C /* ComponentCollectionViewEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F7C254B2F8F005F098C /* ComponentCollectionViewEvent.swift */; };
 		A5C8D8EF253D5B94002ADD9E /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */; };
 		A5EDB6142531B90B00E6078B /* CategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */; };
@@ -113,6 +114,7 @@
 		A5B67F62254B1C8B005F098C /* ThumbnailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailUseCase.swift; sourceTree = "<group>"; };
 		A5B67F6B254B1E32005F098C /* ThumbnailUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailUseCaseTests.swift; sourceTree = "<group>"; };
 		A5B67F6F254B1E72005F098C /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
+		A5B67F78254B2F4B005F098C /* ComponentCollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentCollectionViewDelegate.swift; sourceTree = "<group>"; };
 		A5B67F7C254B2F8F005F098C /* ComponentCollectionViewEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentCollectionViewEvent.swift; sourceTree = "<group>"; };
 		A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
 		A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 				A5EDB61D2532220C00E6078B /* ComponentCollectionViewDataSource.swift */,
 				A5EDB6242532228900E6078B /* ComponentCollectionViewCell.swift */,
 				A5434F0A2538238D00782F2C /* ComponentCollectionView.swift */,
+				A5B67F78254B2F4B005F098C /* ComponentCollectionViewDelegate.swift */,
 				A5B67F7C254B2F8F005F098C /* ComponentCollectionViewEvent.swift */,
 			);
 			path = ComponentCollectionView;
@@ -577,6 +580,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5B67F5A254AFE62005F098C /* Thumbnail.swift in Sources */,
+				A5B67F79254B2F4B005F098C /* ComponentCollectionViewDelegate.swift in Sources */,
 				A5844AA9253D6B0D00A24256 /* EntryImageUseCase.swift in Sources */,
 				A5F893462500A8C7002258EA /* EntryViewController.swift in Sources */,
 				A50E3A9B254960750004DEA7 /* ComponentColor.swift in Sources */,

--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		A5B67F63254B1C8B005F098C /* ThumbnailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F62254B1C8B005F098C /* ThumbnailUseCase.swift */; };
 		A5B67F6C254B1E32005F098C /* ThumbnailUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F6B254B1E32005F098C /* ThumbnailUseCaseTests.swift */; };
 		A5B67F70254B1E72005F098C /* Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F6F254B1E72005F098C /* Thumbnail.swift */; };
+		A5B67F7D254B2F8F005F098C /* ComponentCollectionViewEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F7C254B2F8F005F098C /* ComponentCollectionViewEvent.swift */; };
 		A5C8D8EF253D5B94002ADD9E /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */; };
 		A5EDB6142531B90B00E6078B /* CategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */; };
 		A5EDB61925321E9C00E6078B /* CategoryCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EDB61825321E9C00E6078B /* CategoryCollectionViewDataSource.swift */; };
@@ -112,6 +113,7 @@
 		A5B67F62254B1C8B005F098C /* ThumbnailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailUseCase.swift; sourceTree = "<group>"; };
 		A5B67F6B254B1E32005F098C /* ThumbnailUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailUseCaseTests.swift; sourceTree = "<group>"; };
 		A5B67F6F254B1E72005F098C /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
+		A5B67F7C254B2F8F005F098C /* ComponentCollectionViewEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentCollectionViewEvent.swift; sourceTree = "<group>"; };
 		A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
 		A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		A5EDB61825321E9C00E6078B /* CategoryCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewDataSource.swift; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				A5EDB61D2532220C00E6078B /* ComponentCollectionViewDataSource.swift */,
 				A5EDB6242532228900E6078B /* ComponentCollectionViewCell.swift */,
 				A5434F0A2538238D00782F2C /* ComponentCollectionView.swift */,
+				A5B67F7C254B2F8F005F098C /* ComponentCollectionViewEvent.swift */,
 			);
 			path = ComponentCollectionView;
 			sourceTree = "<group>";
@@ -599,6 +602,7 @@
 				A551143E253B224B0068A4D2 /* ColorSelectCollectionViewCell.swift in Sources */,
 				A5FB9608254ADD9B00FF4C51 /* CGPoint.swift in Sources */,
 				A5F893442500A8C7002258EA /* SceneDelegate.swift in Sources */,
+				A5B67F7D254B2F8F005F098C /* ComponentCollectionViewEvent.swift in Sources */,
 				A52D7056253D51280071613B /* HTTPMethod.swift in Sources */,
 				A52D704E253D50FE0071613B /* NetworkManager.swift in Sources */,
 				A52D7060253D515A0071613B /* NetworkError.swift in Sources */,

--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		A5AEDF4D253FCDA10083F3D2 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AEDF4C253FCDA10083F3D2 /* Component.swift */; };
 		A5AEDF56253FF3670083F3D2 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AEDF55253FF3660083F3D2 /* Components.swift */; };
 		A5B67F5A254AFE62005F098C /* Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F59254AFE62005F098C /* Thumbnail.swift */; };
+		A5B67F63254B1C8B005F098C /* ThumbnailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F62254B1C8B005F098C /* ThumbnailUseCase.swift */; };
+		A5B67F6C254B1E32005F098C /* ThumbnailUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F6B254B1E32005F098C /* ThumbnailUseCaseTests.swift */; };
+		A5B67F70254B1E72005F098C /* Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F6F254B1E72005F098C /* Thumbnail.swift */; };
 		A5C8D8EF253D5B94002ADD9E /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */; };
 		A5EDB6142531B90B00E6078B /* CategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */; };
 		A5EDB61925321E9C00E6078B /* CategoryCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EDB61825321E9C00E6078B /* CategoryCollectionViewDataSource.swift */; };
@@ -106,6 +109,9 @@
 		A5AEDF4C253FCDA10083F3D2 /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		A5AEDF55253FF3660083F3D2 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
 		A5B67F59254AFE62005F098C /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
+		A5B67F62254B1C8B005F098C /* ThumbnailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailUseCase.swift; sourceTree = "<group>"; };
+		A5B67F6B254B1E32005F098C /* ThumbnailUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailUseCaseTests.swift; sourceTree = "<group>"; };
+		A5B67F6F254B1E72005F098C /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
 		A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
 		A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		A5EDB61825321E9C00E6078B /* CategoryCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewDataSource.swift; sourceTree = "<group>"; };
@@ -187,6 +193,7 @@
 				A5AEDF55253FF3660083F3D2 /* Components.swift */,
 				A521F020254557BB0002031A /* Categories.swift */,
 				A50E3AA1254962700004DEA7 /* ComponentColors.swift */,
+				A5B67F6F254B1E72005F098C /* Thumbnail.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -295,6 +302,7 @@
 			children = (
 				A5EEC114253F63200048A13D /* CategoriesUseCase.swift */,
 				A506C98B25426CD100E6BCE6 /* ComponentsUseCase.swift */,
+				A5B67F62254B1C8B005F098C /* ThumbnailUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -305,6 +313,7 @@
 				A53241E7253D9B3D004FEF3C /* EntryImageUseCaseTests.swift */,
 				A5EEC118253F64620048A13D /* CategoryUseCaseTests.swift */,
 				A521F0132543FEA00002031A /* ComponentsUseCaseTests.swift */,
+				A5B67F6B254B1E32005F098C /* ThumbnailUseCaseTests.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -581,6 +590,7 @@
 				A5511454253B5C540068A4D2 /* CornerRadiusView.swift in Sources */,
 				A5EDB6142531B90B00E6078B /* CategoryCollectionViewCell.swift in Sources */,
 				A5EDB61925321E9C00E6078B /* CategoryCollectionViewDataSource.swift in Sources */,
+				A5B67F63254B1C8B005F098C /* ThumbnailUseCase.swift in Sources */,
 				A52D705B253D51440071613B /* HTTPHeaders.swift in Sources */,
 				A506C99A254272D100E6BCE6 /* RetrieveModelFromServer.swift in Sources */,
 				A5EEC115253F63200048A13D /* CategoriesUseCase.swift in Sources */,
@@ -611,12 +621,14 @@
 				A50E3AA2254962700004DEA7 /* ComponentColors.swift in Sources */,
 				A534809B25481E53001C039E /* CategoryComponentManagerTests.swift in Sources */,
 				A5844A9C253D67B600A24256 /* EndPointTests.swift in Sources */,
+				A5B67F70254B1E72005F098C /* Thumbnail.swift in Sources */,
 				A50E3AAC254972AD0004DEA7 /* ModelManageableTests.swift in Sources */,
 				A5EEC119253F64620048A13D /* CategoryUseCaseTests.swift in Sources */,
 				A521F0082543DD8B0002031A /* MockNetworkManagers.swift in Sources */,
 				A506C9A12542758200E6BCE6 /* RetrieveModelFromServerTests.swift in Sources */,
 				A5AEDF56253FF3670083F3D2 /* Components.swift in Sources */,
 				A521F021254557BB0002031A /* Categories.swift in Sources */,
+				A5B67F6C254B1E32005F098C /* ThumbnailUseCaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
+++ b/iOS/IDIllust/IDIllust.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		A5AEDF44253F69700083F3D2 /* UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AEDF43253F69700083F3D2 /* UICollectionView.swift */; };
 		A5AEDF4D253FCDA10083F3D2 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AEDF4C253FCDA10083F3D2 /* Component.swift */; };
 		A5AEDF56253FF3670083F3D2 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AEDF55253FF3660083F3D2 /* Components.swift */; };
+		A5B67F5A254AFE62005F098C /* Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B67F59254AFE62005F098C /* Thumbnail.swift */; };
 		A5C8D8EF253D5B94002ADD9E /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */; };
 		A5EDB6142531B90B00E6078B /* CategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */; };
 		A5EDB61925321E9C00E6078B /* CategoryCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EDB61825321E9C00E6078B /* CategoryCollectionViewDataSource.swift */; };
@@ -104,6 +105,7 @@
 		A5AEDF43253F69700083F3D2 /* UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionView.swift; sourceTree = "<group>"; };
 		A5AEDF4C253FCDA10083F3D2 /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		A5AEDF55253FF3660083F3D2 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
+		A5B67F59254AFE62005F098C /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
 		A5C8D8EE253D5B94002ADD9E /* NetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
 		A5EDB6132531B90B00E6078B /* CategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		A5EDB61825321E9C00E6078B /* CategoryCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewDataSource.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				A5EEC109253F5FC60048A13D /* Category.swift */,
 				A5AEDF4C253FCDA10083F3D2 /* Component.swift */,
 				A534809625481E40001C039E /* CategoryComponentManager.swift */,
+				A5B67F59254AFE62005F098C /* Thumbnail.swift */,
 			);
 			path = CustomizeView;
 			sourceTree = "<group>";
@@ -561,6 +564,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5B67F5A254AFE62005F098C /* Thumbnail.swift in Sources */,
 				A5844AA9253D6B0D00A24256 /* EntryImageUseCase.swift in Sources */,
 				A5F893462500A8C7002258EA /* EntryViewController.swift in Sources */,
 				A50E3A9B254960750004DEA7 /* ComponentColor.swift in Sources */,

--- a/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionView.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionView.swift
@@ -55,17 +55,3 @@ final class ComponentCollectionView: UICollectionView {
         }
     }
 }
-
-enum ComponentCollectionViewEvent {
-    
-    case longPressBegan(CGPoint, IndexPath)
-    case longPressEnded
-    case longPressChanged(CGFloat)
-    
-    static let LongPressGestureStateChanged = Notification.Name("longPressGestureStateChanged")
-    
-    func post() {
-        NotificationCenter.default.post(name: ComponentCollectionViewEvent.LongPressGestureStateChanged,
-                                        object: self)
-    }
-}

--- a/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewDataSource.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewDataSource.swift
@@ -18,7 +18,7 @@ final class ComponentCollectionViewDataSource: NSObject, UICollectionViewDataSou
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ComponentCollectionViewCell.identifier, for: indexPath) as? ComponentCollectionViewCell else { return UICollectionViewCell() }
-        guard let url = components?.model(of: indexPath.item)?.url else { return cell }
+        guard let url = components?.model(of: indexPath.item)?.thumbUrl else { return cell }
         
         cell.imageView.kf.indicatorType = .activity
         cell.imageView.kf.setImage(with: URL(string: url))

--- a/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewDelegate.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  ComponentCollectionViewDelegate.swift
+//  IDIllust
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import UIKit
+
+final class ComponentCollectionViewDelegate: NSObject, UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        ComponentCollectionViewEvent.didSelect(indexPath).post()
+    }
+}

--- a/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewEvent.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/ComponentCollectionView/ComponentCollectionViewEvent.swift
@@ -1,0 +1,32 @@
+//
+//  ComponentCollectionViewEvent.swift
+//  IDIllust
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import UIKit
+
+enum ComponentCollectionViewEvent {
+    
+    case longPressBegan(CGPoint, IndexPath)
+    case longPressEnded
+    case longPressChanged(CGFloat)
+    case didSelect(IndexPath)
+    
+    static let LongPressGestureStateChanged = Notification.Name("longPressGestureStateChanged")
+    static let DidSelect = Notification.Name("didSelect")
+    
+    func post() {
+        switch self {
+        case .longPressBegan(_, _), .longPressChanged(_), .longPressEnded:
+            NotificationCenter.default.post(name: ComponentCollectionViewEvent.LongPressGestureStateChanged,
+                                            object: self)
+        
+        case .didSelect(_):
+            NotificationCenter.default.post(name: ComponentCollectionViewEvent.DidSelect,
+                                            object: self)
+        }
+    }
+}

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -18,7 +18,7 @@ final class CustomizeViewController: UIViewController {
     @IBOutlet private weak var colorSelectView: UIView!
     private var componentCollectionViews: [ComponentCollectionView] = [ComponentCollectionView]()
     private var componentCollectionViewDataSources: [ComponentCollectionViewDataSource] = [ComponentCollectionViewDataSource]()
-    private var thumbnailImageView: [UIImageView] = [UIImageView]()
+    private var thumbnailImageViews: [UIImageView] = [UIImageView]()
     private var componentCollectionViewDelegate: ComponentCollectionViewDelegate? = ComponentCollectionViewDelegate()
     private let categoryCollectionViewDataSource: CategoryCollectionViewDataSource = CategoryCollectionViewDataSource()
     private let categoryComponentManager: CategoryComponentManager = CategoryComponentManager()
@@ -71,7 +71,7 @@ final class CustomizeViewController: UIViewController {
             imageView.centerXAnchor.constraint(equalTo: thumbnailView.centerXAnchor).isActive = true
             imageView.widthAnchor.constraint(equalTo: thumbnailView.widthAnchor).isActive = true
             imageView.heightAnchor.constraint(equalTo: thumbnailView.heightAnchor).isActive = true
-            thumbnailImageView.append(imageView)
+            thumbnailImageViews.append(imageView)
         }
     }
     
@@ -167,6 +167,11 @@ final class CustomizeViewController: UIViewController {
         colorSelectView.isHidden = true
     }
     
+    private func retrieveThumbnail(current: CurrentSelection) {
+        ThumbnailUseCase().retrieveThumbnail(current.categoryId, current.componentId, networkManager: NetworkManager(), successHandler: { model in
+        })
+    }
+    
     // MARK: @objc
     @objc func scrollComponentScrollView() {
         guard let selected = categoryCollectionView.indexPathsForSelectedItems?.first else { return }
@@ -209,6 +214,7 @@ final class CustomizeViewController: UIViewController {
             guard let componentId = categoryComponentManager.component(categoryId, indexPath.item)?.id else { return }
             guard selectionManager.current.componentId != componentId else { return }
             selectionManager.setCurrent(componentId: componentId)
+            retrieveThumbnail(current: selectionManager.current)
             
         default: break
         }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -18,6 +18,7 @@ final class CustomizeViewController: UIViewController {
     @IBOutlet private weak var colorSelectView: UIView!
     private var componentCollectionViews: [ComponentCollectionView] = [ComponentCollectionView]()
     private var componentCollectionViewDataSources: [ComponentCollectionViewDataSource] = [ComponentCollectionViewDataSource]()
+    private var thumbnailImageView: [UIImageView] = [UIImageView]()
     private let categoryCollectionViewDataSource: CategoryCollectionViewDataSource = CategoryCollectionViewDataSource()
     private let categoryComponentManager: CategoryComponentManager = CategoryComponentManager()
     
@@ -37,7 +38,9 @@ final class CustomizeViewController: UIViewController {
     }
     
     private func setComponentCollectionViews() {
-        for _ in 0..<categoryCollectionViewDataSource.modelCount {
+        guard let count = categoryComponentManager.categoryCount else { return }
+        
+        for _ in 0..<count {
             let dataSource = ComponentCollectionViewDataSource()
             componentCollectionViewDataSources.append(dataSource)
             let collectionView = ComponentCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -46,6 +49,21 @@ final class CustomizeViewController: UIViewController {
             collectionView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1).isActive = true
             collectionView.dataSource = dataSource
             collectionView.backgroundColor = .systemBackground
+        }
+    }
+    
+    private func addThumbnailImageViews() {
+        guard let count = categoryComponentManager.categoryCount else { return }
+        
+        for _ in 0..<count {
+            let imageView = UIImageView()
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            thumbnailView.addSubview(imageView)
+            imageView.centerYAnchor.constraint(equalTo: thumbnailView.centerYAnchor).isActive = true
+            imageView.centerXAnchor.constraint(equalTo: thumbnailView.centerXAnchor).isActive = true
+            imageView.widthAnchor.constraint(equalTo: thumbnailView.widthAnchor).isActive = true
+            imageView.heightAnchor.constraint(equalTo: thumbnailView.heightAnchor).isActive = true
+            thumbnailImageView.append(imageView)
         }
     }
     
@@ -91,6 +109,7 @@ final class CustomizeViewController: UIViewController {
         DispatchQueue.main.async { [weak self] in
             self?.setCategoryCollectionView()
             self?.setComponentCollectionViews()
+            self?.addThumbnailImageViews()
         }
         setComponentsUseCase(categoryComponentManager.category(of: 0)?.id)
     }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -19,6 +19,7 @@ final class CustomizeViewController: UIViewController {
     private var componentCollectionViews: [ComponentCollectionView] = [ComponentCollectionView]()
     private var componentCollectionViewDataSources: [ComponentCollectionViewDataSource] = [ComponentCollectionViewDataSource]()
     private var thumbnailImageView: [UIImageView] = [UIImageView]()
+    private var componentCollectionViewDelegate: ComponentCollectionViewDelegate? = ComponentCollectionViewDelegate()
     private let categoryCollectionViewDataSource: CategoryCollectionViewDataSource = CategoryCollectionViewDataSource()
     private let categoryComponentManager: CategoryComponentManager = CategoryComponentManager()
     
@@ -28,6 +29,11 @@ final class CustomizeViewController: UIViewController {
         addObserves()
         setCategoriesUseCase()
         componentScrollView.delegate = self
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        componentCollectionViewDelegate = nil
     }
     
     // MARK: - Methods
@@ -49,6 +55,7 @@ final class CustomizeViewController: UIViewController {
             collectionView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1).isActive = true
             collectionView.dataSource = dataSource
             collectionView.backgroundColor = .systemBackground
+            collectionView.delegate = componentCollectionViewDelegate
         }
     }
     
@@ -79,6 +86,10 @@ final class CustomizeViewController: UIViewController {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(componentCollectionViewEventHandler(_:)),
                                                name: ComponentCollectionViewEvent.LongPressGestureStateChanged,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(componentCollectionViewEventHandler(_:)),
+                                               name: ComponentCollectionViewEvent.DidSelect,
                                                object: nil)
     }
     
@@ -186,6 +197,7 @@ final class CustomizeViewController: UIViewController {
         switch object {
         case .longPressBegan(let origin, _): showColorSelectView(origin)
         case .longPressEnded: hideColorSelectView()
+        case .didSelect(let indexPath): print(indexPath)
         default: break
         }
     }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 final class CustomizeViewController: UIViewController {
     
     // MARK: - Properties
+    @IBOutlet private weak var thumbnailView: UIView!
     @IBOutlet private weak var categoryCollectionView: UICollectionView!
     @IBOutlet private weak var componentsStackView: UIStackView!
     @IBOutlet private weak var componentScrollView: UIScrollView!

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -171,13 +171,18 @@ final class CustomizeViewController: UIViewController {
         ThumbnailUseCase().retrieveThumbnail(current.categoryId, current.componentId, networkManager: NetworkManager(), successHandler: { model in
             DispatchQueue.main.async { [weak self] in
                 guard var categoryIndex = current.categoryIndex else { return }
-                if categoryIndex + 1 >= 9 {
-                    categoryIndex = 0
-                }
-
+                
+                self?.correct(categoryIndex: &categoryIndex)
                 self?.thumbnailImageViews[categoryIndex].kf.setImage(with: URL(string: model.thumbUrl), options: [.keepCurrentImageWhileLoading])
             }
         })
+    }
+    
+    private func correct(categoryIndex: inout Int) {
+        categoryIndex += 1
+        if categoryIndex >= 9 {
+            categoryIndex = 0
+        }
     }
     
     // MARK: @objc

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -185,6 +185,20 @@ final class CustomizeViewController: UIViewController {
         }
     }
     
+    private func changeComponentSelection(_ categoryId: Int, _ componentId: Int) {
+        if selectionManager.isSelectedComponent(categoryId: categoryId, componentId: componentId) {
+            selectionManager.removeCurrentComponent()
+            guard var categoryIndex = selectionManager.current.categoryIndex else { return }
+            componentCollectionViews[categoryIndex].selectItem(at: nil, animated: false, scrollPosition: .bottom)
+            
+            correct(categoryIndex: &categoryIndex)
+            thumbnailImageViews[categoryIndex].image = nil
+        } else {
+            selectionManager.setCurrent(componentId: componentId)
+            retrieveThumbnail(current: selectionManager.current)
+        }
+    }
+    
     // MARK: @objc
     @objc func scrollComponentScrollView() {
         guard let selected = categoryCollectionView.indexPathsForSelectedItems?.first else { return }
@@ -225,10 +239,9 @@ final class CustomizeViewController: UIViewController {
         case .didSelect(let indexPath):
             guard let categoryId = selectionManager.current.categoryId else { return }
             guard let componentId = categoryComponentManager.component(categoryId, indexPath.item)?.id else { return }
-            guard selectionManager.current.componentId != componentId else { return }
-            selectionManager.setCurrent(componentId: componentId)
-            retrieveThumbnail(current: selectionManager.current)
             
+            changeComponentSelection(categoryId, componentId)
+        
         default: break
         }
     }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -169,6 +169,14 @@ final class CustomizeViewController: UIViewController {
     
     private func retrieveThumbnail(current: CurrentSelection) {
         ThumbnailUseCase().retrieveThumbnail(current.categoryId, current.componentId, networkManager: NetworkManager(), successHandler: { model in
+            DispatchQueue.main.async { [weak self] in
+                guard var categoryIndex = current.categoryIndex else { return }
+                if categoryIndex + 1 >= 9 {
+                    categoryIndex = 0
+                }
+
+                self?.thumbnailImageViews[categoryIndex].kf.setImage(with: URL(string: model.thumbUrl), options: [.keepCurrentImageWhileLoading])
+            }
         })
     }
     

--- a/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
@@ -29,6 +29,17 @@ class SelectionManager {
         return selection[categoryId] == componentId
     }
     
+    @discardableResult
+    func removeCurrentComponent() -> Int? {
+        guard let categoryId = current.categoryId else { return nil }
+        
+        let componentId = selection[categoryId]
+        selection[categoryId] = nil
+        current.componentId = nil
+        
+        return componentId
+    }
+    
     private func setSelection(current: CurrentSelection) {
         guard let categoryId = current.categoryId, let componetnId = current.componentId else { return }
         selection[categoryId] = componetnId

--- a/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
@@ -1,0 +1,38 @@
+//
+//  SelectionManager.swift
+//  IDIllust
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import Foundation
+
+class SelectionManager {
+    
+    // categoryId: ComponentId
+    private(set) var selection: [Int: Int] = [Int: Int]()
+    private(set) var current: CurrentSelection = CurrentSelection()
+    
+    func setCurrent(categoryId: Int?, categoryIndex: Int?) {
+        current.categoryId = categoryId
+        current.categoryIndex = categoryIndex
+    }
+    
+    func setCurrent(componentId: Int?) {
+        current.componentId = componentId
+        
+        setSelection(current: current)
+    }
+    
+    private func setSelection(current: CurrentSelection) {
+        guard let categoryId = current.categoryId, let componetnId = current.componentId else { return }
+        selection[categoryId] = componetnId
+    }
+}
+
+class CurrentSelection {
+    var categoryIndex: Int?
+    var categoryId: Int?
+    var componentId: Int?
+}

--- a/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
@@ -25,6 +25,10 @@ class SelectionManager {
         setSelection(current: current)
     }
     
+    func isSelectedComponent(categoryId: Int, componentId: Int) -> Bool {
+        return selection[categoryId] == componentId
+    }
+    
     private func setSelection(current: CurrentSelection) {
         guard let categoryId = current.categoryId, let componetnId = current.componentId else { return }
         selection[categoryId] = componetnId

--- a/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
@@ -13,7 +13,13 @@ struct ThumbnailUseCase: RetrieveModelFromServer {
     typealias Model = Thumbnail
     
     @discardableResult
-    func retrieveThumbnail(with categoryId: Int, _ componentId: Int, networkManager: NetworkManageable, failurehandler: @escaping (UseCaseError) -> Void = { _ in }, successHandler: @escaping (Model) -> Void) -> URLSessionDataTask? {
+    func retrieveThumbnail(_ categoryId: Int?, _ componentId: Int?, networkManager: NetworkManageable, failurehandler: @escaping (UseCaseError) -> Void = { _ in }, successHandler: @escaping (Model) -> Void) -> URLSessionDataTask? {
+        
+        guard let categoryId = categoryId, let componentId = componentId else {
+            failurehandler(.networkError(.requestError))
+            return nil
+        }
+        
         let endPoint = EndPoint(path: .thumbnail(categoryId, componentId))
         
         return retrieveModel(from: endPoint, networkManager: networkManager, failurehandler: failurehandler, successHandler: successHandler)

--- a/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  ThumbnailUseCase.swift
+//  IDIllust
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import Foundation
+
+struct ThumbnailUseCase: RetrieveModelFromServer {
+    
+    typealias Model = Thumbnail
+    
+    @discardableResult
+    func retrieveThumbnail(with categoryId: Int, _ componentId: Int, networkManager: NetworkManageable, failurehandler: @escaping (UseCaseError) -> Void = { _ in }, successHandler: @escaping (Model) -> Void) -> URLSessionDataTask? {
+        let endPoint = EndPoint(path: .thumbnail(categoryId, componentId))
+        
+        return retrieveModel(from: endPoint, networkManager: networkManager, failurehandler: failurehandler, successHandler: successHandler)
+    }
+}

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/CategoryComponentManager.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/CategoryComponentManager.swift
@@ -30,8 +30,12 @@ final class CategoryComponentManager {
         return categories?.model(of: index)
     }
     
-    func components(of categroyId: Int) -> Components? {
-        return componentsOfCategoryId[categroyId]
+    func components(of categoryId: Int) -> Components? {
+        return componentsOfCategoryId[categoryId]
+    }
+    
+    func component(_ categoryId: Int, _ componentIndex: Int) -> Component? {
+        return componentsOfCategoryId[categoryId]?.model(of: componentIndex)
     }
     
     func componentsCount(of categoryId: Int) -> Int? {

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
@@ -23,11 +23,5 @@ struct Component: Decodable {
     
     let id: Int
     let name: String
-    let url: String
-    
-    enum CodingKeys: String, CodingKey {
-        case id
-        case name
-        case url = "thumb_url"
-    }
+    let thumbUrl: String
 }

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/Thumbnail.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/Thumbnail.swift
@@ -1,0 +1,14 @@
+//
+//  Thumbnail.swift
+//  IDIllust
+//
+//  Created by 신한섭 on 2020/10/29.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import Foundation
+
+struct Thumbnail: Decodable {
+    
+    let thumbUrl: String
+}

--- a/iOS/IDIllust/IDIllust/Network/EndPoint.swift
+++ b/iOS/IDIllust/IDIllust/Network/EndPoint.swift
@@ -31,6 +31,7 @@ struct EndPoint {
         case entry
         case categories
         case components(Int)
+        case thumbnail(Int, Int)
         
         var description: String {
             switch self {
@@ -40,6 +41,8 @@ struct EndPoint {
                 return "/api/categories"
             case .components(let categoryId):
                 return "/api/categories/\(categoryId)/components"
+            case .thumbnail(let categoryId, let componentId):
+                return "/api/categories/\(categoryId)/components/\(componentId)"
             }
         }
     }

--- a/iOS/IDIllust/IDIllust/Protocols/RetrieveModelFromServer.swift
+++ b/iOS/IDIllust/IDIllust/Protocols/RetrieveModelFromServer.swift
@@ -26,7 +26,9 @@ extension RetrieveModelFromServer where Model: Decodable {
                                     switch result {
                                     case .success(let data):
                                         do {
-                                            let model = try JSONDecoder().decode(Model.self, from: data)
+                                            let decoder = JSONDecoder()
+                                            decoder.keyDecodingStrategy = .convertFromSnakeCase
+                                            let model = try decoder.decode(Model.self, from: data)
                                             successHandler(model)
                                         } catch {
                                             failurehandler(.decodeError)

--- a/iOS/IDIllust/IDIllust/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/IDIllust/IDIllust/StoryBoard/Base.lproj/Main.storyboard
@@ -78,6 +78,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1lZ-Ip-0rH" userLabel="ThumbnailView">
+                                <rect key="frame" x="52.333333333333343" y="44" width="270.33333333333326" height="360.33333333333331"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="1lZ-Ip-0rH" secondAttribute="height" multiplier="3:4" id="ZDu-kx-I0B"/>
+                                </constraints>
+                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="kDE-6u-U7f" userLabel="Container Stack View">
                                 <rect key="frame" x="0.0" y="404.33333333333326" width="375" height="324.66666666666674"/>
                                 <subviews>
@@ -159,12 +166,6 @@
                                     <constraint firstItem="SRJ-t1-thA" firstAttribute="height" secondItem="kDE-6u-U7f" secondAttribute="height" multiplier="0.2" id="fJK-Jr-NrH"/>
                                 </constraints>
                             </stackView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="thumb_skin_2" translatesAutoresizingMaskIntoConstraints="NO" id="aqu-Mu-v2u" userLabel="PreView Image View">
-                                <rect key="frame" x="52.333333333333343" y="44" width="270.33333333333326" height="360.33333333333331"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="aqu-Mu-v2u" secondAttribute="height" multiplier="3:4" id="ayJ-fZ-f14"/>
-                                </constraints>
-                            </imageView>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JdK-C9-rsT">
                                 <rect key="frame" x="0.0" y="44" width="240" height="66"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
@@ -176,12 +177,12 @@
                         <viewLayoutGuide key="safeArea" id="Y0t-gu-9BP"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="aqu-Mu-v2u" firstAttribute="centerX" secondItem="Y0t-gu-9BP" secondAttribute="centerX" id="2WI-IE-BBY"/>
-                            <constraint firstItem="kDE-6u-U7f" firstAttribute="top" secondItem="aqu-Mu-v2u" secondAttribute="bottom" id="5We-39-oYE"/>
+                            <constraint firstItem="kDE-6u-U7f" firstAttribute="top" secondItem="1lZ-Ip-0rH" secondAttribute="bottom" id="3IG-XE-SYF"/>
                             <constraint firstItem="kDE-6u-U7f" firstAttribute="height" secondItem="Z8d-ty-sDV" secondAttribute="height" multiplier="0.4" id="HEJ-Gp-wIy"/>
+                            <constraint firstItem="1lZ-Ip-0rH" firstAttribute="top" secondItem="Y0t-gu-9BP" secondAttribute="top" id="M4k-CK-agF"/>
                             <constraint firstItem="Y0t-gu-9BP" firstAttribute="trailing" secondItem="kDE-6u-U7f" secondAttribute="trailing" id="PEG-bj-2uU"/>
                             <constraint firstItem="Y0t-gu-9BP" firstAttribute="bottom" secondItem="kDE-6u-U7f" secondAttribute="bottom" id="Zgb-QA-d9b"/>
-                            <constraint firstItem="aqu-Mu-v2u" firstAttribute="top" secondItem="Y0t-gu-9BP" secondAttribute="top" id="hVO-qW-IOs"/>
+                            <constraint firstItem="1lZ-Ip-0rH" firstAttribute="centerX" secondItem="Y0t-gu-9BP" secondAttribute="centerX" id="pa5-dR-hd6"/>
                             <constraint firstItem="kDE-6u-U7f" firstAttribute="leading" secondItem="Y0t-gu-9BP" secondAttribute="leading" id="wi1-wa-s71"/>
                         </constraints>
                     </view>
@@ -191,6 +192,7 @@
                         <outlet property="colorSelectView" destination="JdK-C9-rsT" id="1h9-zZ-h3L"/>
                         <outlet property="componentScrollView" destination="JUz-cU-jmh" id="38g-d3-0pR"/>
                         <outlet property="componentsStackView" destination="Zc7-k9-Gr9" id="b9R-Mr-Cuy"/>
+                        <outlet property="thumbnailView" destination="1lZ-Ip-0rH" id="e5X-r1-aZX"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jBE-hf-gNy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -310,7 +312,6 @@
     </designables>
     <resources>
         <image name="checkmark" catalog="system" width="128" height="114"/>
-        <image name="thumb_skin_2" width="300" height="400"/>
         <namedColor name="DivisionColor">
             <color red="0.90600001811981201" green="0.90600001811981201" blue="0.90600001811981201" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>

--- a/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
@@ -57,6 +57,13 @@ final class CategoryComponentManagerTests: XCTestCase {
         XCTAssertEqual(categoryComponentManager.componentsCount(of: category.id), 1)
     }
     
+    func testGetComponent() {
+        XCTAssertNil(categoryComponentManager.component(category.id, 0))
+        categoryComponentManager.insert(categories: categories)
+        categoryComponentManager.insert(components: components, by: category.id)
+        XCTAssertEqual(categoryComponentManager.component(category.id, 0), component)
+    }
+    
     func testIsExistComponents() {
         categoryComponentManager.insert(categories: categories)
         categoryComponentManager.insert(components: components, by: category.id)

--- a/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
@@ -21,7 +21,7 @@ final class CategoryComponentManagerTests: XCTestCase {
         categoryComponentManager = CategoryComponentManager()
         category = IDIllust.Category(id: 1, name: "category", url: "url")
         categories = Categories(models: [category])
-        component = Component(id: 1, name: "component", url: "url")
+        component = Component(id: 1, name: "component", thumbUrl: "url")
         components = Components(models: [component])
     }
     

--- a/iOS/IDIllust/IDIllustTests/EndPointTests.swift
+++ b/iOS/IDIllust/IDIllustTests/EndPointTests.swift
@@ -25,4 +25,9 @@ final class EndPointTests: XCTestCase {
         let components = EndPoint(path: .components(1))
         XCTAssertEqual(components.url, URL(string: "http://3.34.77.7/api/categories/1/components"))
     }
+    
+    func testThumbnailEndPointValid() {
+        let thumbnail = EndPoint(path: .thumbnail(1, 1))
+        XCTAssertEqual(thumbnail.url, URL(string: "http://3.34.77.7/api/categories/1/components/1"))
+    }
 }

--- a/iOS/IDIllust/IDIllustTests/Extension/Components.swift
+++ b/iOS/IDIllust/IDIllustTests/Extension/Components.swift
@@ -10,14 +10,20 @@
 
 extension Component: Equatable, Encodable {
     public static func == (lhs: Component, rhs: Component) -> Bool {
-        return lhs.id == rhs.id && lhs.name == rhs.name && lhs.url == rhs.url
+        return lhs.id == rhs.id && lhs.name == rhs.name && lhs.thumbUrl == rhs.thumbUrl
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
-        try container.encode(url, forKey: .url)
+        try container.encode(thumbUrl, forKey: .thumbUrl)
+    }
+    
+    enum CodingKeys : String, CodingKey{
+        case id
+        case name
+        case thumbUrl
     }
 }
 

--- a/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
+++ b/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
@@ -1,0 +1,15 @@
+//
+//  CurrentSelection.swift
+//  IDIllustTests
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+@testable import IDIllust
+
+extension CurrentSelection: Equatable {
+    public static func == (lhs: CurrentSelection, rhs: CurrentSelection) -> Bool {
+        return lhs.categoryIndex == rhs.categoryIndex && lhs.categoryId == rhs.categoryId && lhs.componentId == rhs.componentId
+    }
+}

--- a/iOS/IDIllust/IDIllustTests/Extension/Thumbnail.swift
+++ b/iOS/IDIllust/IDIllustTests/Extension/Thumbnail.swift
@@ -1,0 +1,25 @@
+//
+//  Thumbnail.swift
+//  IDIllustTests
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+@testable import IDIllust
+import Foundation
+
+extension Thumbnail: Equatable, Encodable {
+    public static func == (lhs: Thumbnail, rhs: Thumbnail) -> Bool {
+        return lhs.thumbUrl == rhs.thumbUrl
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(thumbUrl, forKey: .thumbUrl)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case thumbUrl
+    }
+}

--- a/iOS/IDIllust/IDIllustTests/Extension/Thumbnail.swift
+++ b/iOS/IDIllust/IDIllustTests/Extension/Thumbnail.swift
@@ -7,7 +7,6 @@
 //
 
 @testable import IDIllust
-import Foundation
 
 extension Thumbnail: Equatable, Encodable {
     public static func == (lhs: Thumbnail, rhs: Thumbnail) -> Bool {

--- a/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
@@ -13,6 +13,8 @@ class SelectionManagerTests: XCTestCase {
     
     private var selectionManager: SelectionManager!
     private var currentSelection: CurrentSelection!
+    private let categoryId = 0
+    private let componentId = 1
     
     override func setUpWithError() throws {
         selectionManager = SelectionManager()
@@ -20,26 +22,44 @@ class SelectionManagerTests: XCTestCase {
     }
     
     func testSetCurrentCategoryIdCategoryIndex() {
-        currentSelection.categoryId = 0
+        currentSelection.categoryId = categoryId
         currentSelection.categoryIndex = 0
-        
-        selectionManager.setCurrent(categoryId: 0, categoryIndex: 0)
+        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
         
         XCTAssertEqual(selectionManager.current, currentSelection)
     }
     
     func testSetCurrentComponentId() {
-        currentSelection.componentId = 1
-        
-        selectionManager.setCurrent(componentId: 1)
+        currentSelection.componentId = componentId
+        selectionManager.setCurrent(componentId: componentId)
         
         XCTAssertEqual(selectionManager.current, currentSelection)
     }
     
     func testSelectionValid() {
-        selectionManager.setCurrent(categoryId: 1, categoryIndex: 0)
-        selectionManager.setCurrent(componentId: 2)
+        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
+        selectionManager.setCurrent(componentId: componentId)
         
-        XCTAssertEqual(selectionManager.selection, [1: 2])
+        XCTAssertEqual(selectionManager.selection, [categoryId: componentId])
+    }
+    
+    func testIsSelectedComponent() {
+        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
+        selectionManager.setCurrent(componentId: componentId)
+        
+        XCTAssertTrue(selectionManager.isSelectedComponent(categoryId: categoryId, componentId: componentId))
+        XCTAssertFalse(selectionManager.isSelectedComponent(categoryId: categoryId, componentId: 9))
+    }
+    
+    func testRemoveCurrentComponent() {
+        XCTAssertNil(selectionManager.removeCurrentComponent())
+        
+        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
+        selectionManager.setCurrent(componentId: componentId)
+        
+        XCTAssertEqual(selectionManager.removeCurrentComponent(), componentId)
+        
+        XCTAssertNil(selectionManager.current.componentId)
+        XCTAssertNil(selectionManager.selection[categoryId])
     }
 }

--- a/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
@@ -1,0 +1,45 @@
+//
+//  SelectionManagerTests.swift
+//  IDIllustTests
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+@testable import IDIllust
+import XCTest
+
+class SelectionManagerTests: XCTestCase {
+    
+    private var selectionManager: SelectionManager!
+    private var currentSelection: CurrentSelection!
+    
+    override func setUpWithError() throws {
+        selectionManager = SelectionManager()
+        currentSelection = CurrentSelection()
+    }
+    
+    func testSetCurrentCategoryIdCategoryIndex() {
+        currentSelection.categoryId = 0
+        currentSelection.categoryIndex = 0
+        
+        selectionManager.setCurrent(categoryId: 0, categoryIndex: 0)
+        
+        XCTAssertEqual(selectionManager.current, currentSelection)
+    }
+    
+    func testSetCurrentComponentId() {
+        currentSelection.componentId = 1
+        
+        selectionManager.setCurrent(componentId: 1)
+        
+        XCTAssertEqual(selectionManager.current, currentSelection)
+    }
+    
+    func testSelectionValid() {
+        selectionManager.setCurrent(categoryId: 1, categoryIndex: 0)
+        selectionManager.setCurrent(componentId: 2)
+        
+        XCTAssertEqual(selectionManager.selection, [1: 2])
+    }
+}

--- a/iOS/IDIllust/IDIllustTests/UseCase/ComponentsUseCaseTests.swift
+++ b/iOS/IDIllust/IDIllustTests/UseCase/ComponentsUseCaseTests.swift
@@ -15,7 +15,7 @@ class ComponentsUseCaseTests: XCTestCase {
     private var model: Components!
 
     override func setUpWithError() throws {
-        let component = IDIllust.Component(id: 1, name: "test", url: "url")
+        let component = IDIllust.Component(id: 1, name: "test", thumbUrl: "url")
         model = Components(models: [component])
     }
     

--- a/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
+++ b/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
@@ -21,7 +21,7 @@ class ThumbnailUseCaseTests: XCTestCase {
     func testSuccess() {
         mockNetworkManager = MockSuccessNetworkManager(model: model)
         
-        ThumbnailUseCase().retrieveThumbnail(with: 0, 0,
+        ThumbnailUseCase().retrieveThumbnail(0, 0,
                                              networkManager: mockNetworkManager,
                                              successHandler: { model in
                                                 XCTAssertEqual(model, self.model)

--- a/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
+++ b/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
@@ -1,0 +1,30 @@
+//
+//  ThumbnailUseCaseTests.swift
+//  IDIllustTests
+//
+//  Created by 신한섭 on 2020/10/30.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+@testable import IDIllust
+import XCTest
+
+class ThumbnailUseCaseTests: XCTestCase {
+
+    private var mockNetworkManager: NetworkManageable!
+    private var model: Thumbnail!
+
+    override func setUpWithError() throws {
+        model = Thumbnail(thumbUrl: "test")
+    }
+    
+    func testSuccess() {
+        mockNetworkManager = MockSuccessNetworkManager(model: model)
+        
+        ThumbnailUseCase().retrieveThumbnail(with: 0, 0,
+                                             networkManager: mockNetworkManager,
+                                             successHandler: { model in
+                                                XCTAssertEqual(model, self.model)
+                                             })
+    }
+}


### PR DESCRIPTION
- JsonDecoder keyDecodingStrategy을 convertFromSnakeCase로 적용하여 프로퍼티명 변경을 위헌 CodingKeys enum을 제거했습니다.
- ThumbnailImageViews프로퍼티를 생성하여 각 category에 맞는 imageview를 생성해줬습니다. 
- UICollectionViewDelegate를 분리했습니다. extension으로 빼지 않은 이유는 현재 CustomizeViewController에서 UIScrollViewDelegate를 채택하고있기 때문에 두개의 delegate가 충돌해서 원하는 동작이 진행되지 않기 때문입니다.
- 선택정보를 저장하기 위해 SelectionManager를 만들어 선택정보를 저장했습니다.
- 셀이 선택되면 selectionManager의 내부 변수를 변경합니다. 선택한 셀을 재선택 하면 해당 셀을 선택 해제 하도록 했습니다.
- 이 과정에서 하드코딩이 너무 많아 고민입니다.
