### PR TITLE
ColorSelectView networking

### DIFF
--- a/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
+++ b/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
@@ -12,6 +12,7 @@ final class ColorSelectViewController: UIViewController {
     
     // MARK: properties
     @IBOutlet weak var colorSelectCollectionView: UICollectionView!
+    var colors: [Color]?
     
     // MARK: LifeCycles
     override func viewDidLoad() {
@@ -60,11 +61,14 @@ final class ColorSelectViewController: UIViewController {
 
 extension ColorSelectViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 5
+        return colors?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ColorSelectCollectionViewCell.identifier, for: indexPath) as? ColorSelectCollectionViewCell else { return UICollectionViewCell() }
+        guard let url = colors?[indexPath.item].url else { return cell }
+        cell.colorImageView.kf.indicatorType = .activity
+        cell.colorImageView.kf.setImage(with: URL(string: url))
         return cell
     }
 }

--- a/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
+++ b/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
@@ -28,10 +28,20 @@ final class ColorSelectViewController: UIViewController {
             }
             
             reloadQueue.async { [weak self] in
+                guard let id = self?.selectedId else { return }
+                guard let selectedIndex = self?.colorIndex(of: id) else { return }
+                
+                DispatchQueue.main.async {
+                    self?.colorSelectCollectionView.selectItem(at: IndexPath(item: selectedIndex, section: 0), animated: false, scrollPosition: .top)
+                }
+            }
+            
+            reloadQueue.async { [weak self] in
                 self?.delegate?.colorSelectCollectionViewReloaded(self?.colorSelectCollectionView)
             }
         }
     }
+    var selectedId: Int?
     
     // MARK: LifeCycles
     override func viewDidLoad() {
@@ -56,6 +66,14 @@ final class ColorSelectViewController: UIViewController {
                                                object: nil)
     }
     
+    private func colorIndex(of colorId: Int) -> Int? {
+        for index in 0..<(colors?.count ?? 0) where colors?[index].id == colorId {
+            return index
+        }
+        
+        return nil
+    }
+    
     // MARK: @objc
     @objc func selectCell(_ notification: Notification) {
         guard let object = notification.object as? ComponentCollectionViewEvent else { return }
@@ -69,7 +87,7 @@ final class ColorSelectViewController: UIViewController {
             let selectedIndexPath = colorSelectCollectionView.indexPathsForSelectedItems?.first
             
             guard selectedIndexPath != currentIndexPath else { return }
-                
+            
             colorSelectCollectionView.selectItem(at: currentIndexPath, animated: false, scrollPosition: .left)
             UIDevice.vibrate(style: .light)
             
@@ -78,7 +96,7 @@ final class ColorSelectViewController: UIViewController {
                 delegate?.colorSelected(nil)
                 return
             }
-
+            
             delegate?.colorSelected(colors?[selected].id)
             
         default: break

--- a/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
+++ b/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
@@ -72,6 +72,7 @@ final class ColorSelectViewController: UIViewController {
             colorSelectCollectionView.selectItem(at: currentIndexPath, animated: false, scrollPosition: .left)
             UIDevice.vibrate(style: .light)
             
+        case .longPressEnded:
         default: break
         }
     }

--- a/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
+++ b/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
@@ -8,11 +8,29 @@
 
 import UIKit
 
+protocol ColorChangedDelegate: AnyObject {
+    func completionHandler(_ colorSelectCollectionView: UICollectionView?)
+}
+
 final class ColorSelectViewController: UIViewController {
     
     // MARK: properties
     @IBOutlet weak var colorSelectCollectionView: UICollectionView!
-    var colors: [Color]?
+    private let reloadQueue = DispatchQueue(label: "reloadQueue")
+    weak var colorChangedDelegate: ColorChangedDelegate?
+    var colors: [Color]? {
+        didSet {
+            reloadQueue.async {
+                DispatchQueue.main.sync { [weak self] in
+                    self?.colorSelectCollectionView.reloadData()
+                }
+            }
+            
+            reloadQueue.async { [weak self] in
+                self?.colorChangedDelegate?.completionHandler(self?.colorSelectCollectionView)
+            }
+        }
+    }
     
     // MARK: LifeCycles
     override func viewDidLoad() {

--- a/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
+++ b/iOS/IDIllust/IDIllust/ColorSelectView/ColorSelectViewController.swift
@@ -8,8 +8,9 @@
 
 import UIKit
 
-protocol ColorChangedDelegate: AnyObject {
-    func completionHandler(_ colorSelectCollectionView: UICollectionView?)
+protocol ColorSelectViewControllerDelegate: AnyObject {
+    func colorSelectCollectionViewReloaded(_ colorSelectCollectionView: UICollectionView?)
+    func colorSelected(_ colorId: Int?)
 }
 
 final class ColorSelectViewController: UIViewController {
@@ -17,7 +18,7 @@ final class ColorSelectViewController: UIViewController {
     // MARK: properties
     @IBOutlet weak var colorSelectCollectionView: UICollectionView!
     private let reloadQueue = DispatchQueue(label: "reloadQueue")
-    weak var colorChangedDelegate: ColorChangedDelegate?
+    weak var delegate: ColorSelectViewControllerDelegate?
     var colors: [Color]? {
         didSet {
             reloadQueue.async {
@@ -27,7 +28,7 @@ final class ColorSelectViewController: UIViewController {
             }
             
             reloadQueue.async { [weak self] in
-                self?.colorChangedDelegate?.completionHandler(self?.colorSelectCollectionView)
+                self?.delegate?.colorSelectCollectionViewReloaded(self?.colorSelectCollectionView)
             }
         }
     }
@@ -73,6 +74,13 @@ final class ColorSelectViewController: UIViewController {
             UIDevice.vibrate(style: .light)
             
         case .longPressEnded:
+            guard let selected = colorSelectCollectionView.indexPathsForSelectedItems?.first?.item else {
+                delegate?.colorSelected(nil)
+                return
+            }
+
+            delegate?.colorSelected(colors?[selected].id)
+            
         default: break
         }
     }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -152,6 +152,7 @@ final class CustomizeViewController: UIViewController {
         guard let colorSelectViewController = children.first as? ColorSelectViewController else { return }
         
         let colors = categoryComponentManager.component(categoryId, componentIndexPath.item)?.colors
+        colorSelectViewController.colorChangedDelegate = self
         colorSelectViewController.colors = colors
     }
     
@@ -271,5 +272,10 @@ extension CustomizeViewController: UIScrollViewDelegate {
             setComponentsUseCase(categoryComponentManager.category(of: index)?.id)
             return
         }
+    }
+}
+
+extension CustomizeViewController: ColorChangedDelegate {
+    func completionHandler(_ colorSelectCollectionView: UICollectionView?) {
     }
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -161,7 +161,7 @@ final class CustomizeViewController: UIViewController {
     }
     
     private func retrieveThumbnail(current: CurrentSelection) {
-        ThumbnailUseCase().retrieveThumbnail(current.categoryId, current.componentId, networkManager: NetworkManager(), successHandler: { model in
+        ThumbnailUseCase().retrieveThumbnail(current.categoryId, current.componentInfo?.componentId, networkManager: NetworkManager(), successHandler: { model in
             DispatchQueue.main.async { [weak self] in
                 guard var categoryIndex = current.categoryIndex else { return }
                 

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -286,6 +286,7 @@ extension CustomizeViewController: ColorSelectViewControllerDelegate {
     }
     
     func colorSelected(_ colorId: Int?) {
+        selectionManager.setCurrent(colorId: colorId)
         DispatchQueue.main.async { [weak self] in
             self?.colorSelectView.isHidden = true
         }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -295,8 +295,10 @@ extension CustomizeViewController: ColorSelectViewControllerDelegate {
         let componentIndexPath = selectionManager.current.componentInfo?.componentIndexPath
 
         DispatchQueue.main.async { [weak self] in
-            self?.componentCollectionViews[categoryIndex].selectItem(at: componentIndexPath, animated: false, scrollPosition: .bottom)
+            self?.componentCollectionViews[categoryIndex].selectItem(at: componentIndexPath, animated: false, scrollPosition: .right)
             self?.colorSelectView.isHidden = true
         }
+        
+        retrieveThumbnail(current: selectionManager.current)
     }
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -130,17 +130,21 @@ final class CustomizeViewController: UIViewController {
         }
     }
     
-    private func setColorSelectViewFrame(origin: CGPoint) {
-        guard let colorSelectVC = children.first as? ColorSelectViewController else { return }
-        colorSelectView.frame = CGRect(origin: origin, size: colorSelectVC.colorSelectCollectionView.contentSize)
+    private func setColorSelectViewFrame(size: CGSize?) {
+        guard let size = size else { return }
+        colorSelectView.frame = CGRect(origin: colorSelectView.frame.origin, size: size)
     }
     
-    private func correct(point: inout CGPoint) {
-        point.y -= colorSelectView.frame.height / 1.5
+    private func correctColorSelectViewOrigin() {
+        var mutablePoint = colorSelectView.frame.origin
         
-        guard point.x + colorSelectView.frame.width >= view.frame.width else { return }
+        mutablePoint.y -= colorSelectView.frame.height / 1.5
         
-        point.x = view.frame.width - colorSelectView.frame.width
+        if colorSelectView.frame.maxX >= view.frame.width {
+            mutablePoint.x = view.frame.width - colorSelectView.frame.width
+        }
+        
+        colorSelectView.frame = CGRect(origin: mutablePoint, size: colorSelectView.frame.size)
     }
     
     private func setColorSelectView(_ point: CGPoint, _ componentIndexPath: IndexPath) {
@@ -277,5 +281,12 @@ extension CustomizeViewController: UIScrollViewDelegate {
 
 extension CustomizeViewController: ColorChangedDelegate {
     func completionHandler(_ colorSelectCollectionView: UICollectionView?) {
+        DispatchQueue.main.async { [weak self] in
+            self?.setColorSelectViewFrame(size: colorSelectCollectionView?.contentSize)
+            self?.correctColorSelectViewOrigin()
+            self?.colorSelectView.isHidden = false
+        }
+        
+        UIDevice.vibrate(style: .light)
     }
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -165,7 +165,7 @@ final class CustomizeViewController: UIViewController {
     }
     
     private func retrieveThumbnail(current: CurrentSelection) {
-        ThumbnailUseCase().retrieveThumbnail(current.categoryId, current.componentInfo?.componentId, networkManager: NetworkManager(), successHandler: { model in
+        ThumbnailUseCase().retrieveThumbnail(selectionManager.current, networkManager: NetworkManager(), successHandler: { model in
             DispatchQueue.main.async { [weak self] in
                 guard var categoryIndex = current.categoryIndex else { return }
                 

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -143,16 +143,16 @@ final class CustomizeViewController: UIViewController {
         point.x = view.frame.width - colorSelectView.frame.width
     }
     
-    private func showColorSelectView(_ point: CGPoint) {
-        guard let selected = categoryCollectionView.indexPathsForSelectedItems?.first?.item else { return }
-        var convertedPoint = point.convert(to: [componentCollectionViews[selected], componentsStackView, view])
+    private func setColorSelectView(_ point: CGPoint, _ componentIndexPath: IndexPath) {
+        guard let selected = selectionManager.current.categoryIndex else { return }
+        guard let categoryId = selectionManager.current.categoryId else { return }
+        let convertedPoint = point.convert(to: [componentCollectionViews[selected], componentsStackView, view])
+        colorSelectView.frame = CGRect(origin: convertedPoint, size: colorSelectView.frame.size)
         
-        correct(point: &convertedPoint)
+        guard let colorSelectViewController = children.first as? ColorSelectViewController else { return }
         
-        setColorSelectViewFrame(origin: convertedPoint)
-        
-        colorSelectView.isHidden = false
-        UIDevice.vibrate(style: .light)
+        let colors = categoryComponentManager.component(categoryId, componentIndexPath.item)?.colors
+        colorSelectViewController.colors = colors
     }
     
     private func hideColorSelectView() {
@@ -176,7 +176,7 @@ final class CustomizeViewController: UIViewController {
         categoryIndex += 1
         
         guard categoryIndex >= numOfCategories else { return }
-            categoryIndex = 0
+        categoryIndex = 0
     }
     
     private func changeComponentSelection(_ categoryId: Int, _ componentId: Int) {
@@ -227,15 +227,15 @@ final class CustomizeViewController: UIViewController {
         guard let object = notification.object as? ComponentCollectionViewEvent else { return }
         
         switch object {
-        case .longPressBegan(let origin, _): showColorSelectView(origin)
+        case .longPressBegan(let origin, let indexPath): setColorSelectView(origin, indexPath)
         case .longPressEnded: hideColorSelectView()
-        
+            
         case .didSelect(let indexPath):
             guard let categoryId = selectionManager.current.categoryId else { return }
             guard let componentId = categoryComponentManager.component(categoryId, indexPath.item)?.id else { return }
             
             changeComponentSelection(categoryId, componentId)
-        
+            
         default: break
         }
     }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -159,6 +159,7 @@ final class CustomizeViewController: UIViewController {
         let colors = component?.colors
         
         colorSelectViewController.delegate = self
+        colorSelectViewController.selectedId = selectionManager.colorSelectionForEachComponent[component?.id] ?? colors?.first?.id
         colorSelectViewController.colors = colors
         
         selectionManager.setCurrent(componentId: component?.id, componentIndexPath: componentIndexPath)

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -156,12 +156,8 @@ final class CustomizeViewController: UIViewController {
         guard let colorSelectViewController = children.first as? ColorSelectViewController else { return }
         
         let colors = categoryComponentManager.component(categoryId, componentIndexPath.item)?.colors
-        colorSelectViewController.colorChangedDelegate = self
+        colorSelectViewController.delegate = self
         colorSelectViewController.colors = colors
-    }
-    
-    private func hideColorSelectView() {
-        colorSelectView.isHidden = true
     }
     
     private func retrieveThumbnail(current: CurrentSelection) {
@@ -278,8 +274,8 @@ extension CustomizeViewController: UIScrollViewDelegate {
     }
 }
 
-extension CustomizeViewController: ColorChangedDelegate {
-    func completionHandler(_ colorSelectCollectionView: UICollectionView?) {
+extension CustomizeViewController: ColorSelectViewControllerDelegate {
+    func colorSelectCollectionViewReloaded(_ colorSelectCollectionView: UICollectionView?) {
         DispatchQueue.main.async { [weak self] in
             self?.setColorSelectViewFrame(size: colorSelectCollectionView?.contentSize)
             self?.correctColorSelectViewOrigin()
@@ -287,5 +283,11 @@ extension CustomizeViewController: ColorChangedDelegate {
         }
         
         UIDevice.vibrate(style: .light)
+    }
+    
+    func colorSelected(_ colorId: Int?) {
+        DispatchQueue.main.async { [weak self] in
+            self?.colorSelectView.isHidden = true
+        }
     }
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -155,9 +155,13 @@ final class CustomizeViewController: UIViewController {
         
         guard let colorSelectViewController = children.first as? ColorSelectViewController else { return }
         
-        let colors = categoryComponentManager.component(categoryId, componentIndexPath.item)?.colors
+        let component = categoryComponentManager.component(categoryId, componentIndexPath.item)
+        let colors = component?.colors
+        
         colorSelectViewController.delegate = self
         colorSelectViewController.colors = colors
+        
+        selectionManager.setCurrent(componentId: component?.id, componentIndexPath: componentIndexPath)
     }
     
     private func retrieveThumbnail(current: CurrentSelection) {
@@ -287,7 +291,11 @@ extension CustomizeViewController: ColorSelectViewControllerDelegate {
     
     func colorSelected(_ colorId: Int?) {
         selectionManager.setCurrent(colorId: colorId)
+        guard let categoryIndex = selectionManager.current.categoryIndex else { return }
+        let componentIndexPath = selectionManager.current.componentInfo?.componentIndexPath
+
         DispatchQueue.main.async { [weak self] in
+            self?.componentCollectionViews[categoryIndex].selectItem(at: componentIndexPath, animated: false, scrollPosition: .bottom)
             self?.colorSelectView.isHidden = true
         }
     }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -233,7 +233,6 @@ final class CustomizeViewController: UIViewController {
         
         switch object {
         case .longPressBegan(let origin, let indexPath): setColorSelectView(origin, indexPath)
-        case .longPressEnded: hideColorSelectView()
             
         case .didSelect(let indexPath):
             guard let categoryId = selectionManager.current.categoryId else { return }

--- a/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/CustomizeViewController.swift
@@ -171,10 +171,12 @@ final class CustomizeViewController: UIViewController {
     }
     
     private func correct(categoryIndex: inout Int) {
+        guard let numOfCategories = categoryComponentManager.categoryCount else { return }
+        
         categoryIndex += 1
-        if categoryIndex >= 9 {
+        
+        guard categoryIndex >= numOfCategories else { return }
             categoryIndex = 0
-        }
     }
     
     private func changeComponentSelection(_ categoryId: Int, _ componentId: Int) {

--- a/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
@@ -12,6 +12,8 @@ final class SelectionManager {
     
     // categoryId: ComponentInfo(componentId, colorId)
     private(set) var selection: [Int: ComponentInfo] = [Int: ComponentInfo]()
+    // componentId: colorId
+    private(set) var colorSelectionForEachComponent: [Int?: Int?] = [Int?: Int?]()
     private(set) var current: CurrentSelection = CurrentSelection()
     
     func setCurrent(categoryId: Int?, categoryIndex: Int?) {
@@ -28,7 +30,7 @@ final class SelectionManager {
     }
     
     func setCurrent(colorId: Int?) {
-        current.componentInfo?.corlorId = colorId
+        current.componentInfo?.colorId = colorId
         
         setSelection(current: current)
     }
@@ -52,6 +54,7 @@ final class SelectionManager {
     private func setSelection(current: CurrentSelection) {
         guard let categoryId = current.categoryId, let componentInfo = current.componentInfo else { return }
         selection[categoryId] = componentInfo
+        colorSelectionForEachComponent[componentInfo.componentId] = componentInfo.colorId
     }
 }
 
@@ -64,5 +67,5 @@ struct CurrentSelection {
 struct ComponentInfo {
     var componentId: Int?
     var componentIndexPath: IndexPath?
-    var corlorId: Int?
+    var colorId: Int?
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
@@ -10,8 +10,8 @@ import Foundation
 
 final class SelectionManager {
     
-    // categoryId: ComponentId
-    private(set) var selection: [Int: Int] = [Int: Int]()
+    // categoryId: ComponentInfo(componentId, colorId)
+    private(set) var selection: [Int: ComponentInfo] = [Int: ComponentInfo]()
     private(set) var current: CurrentSelection = CurrentSelection()
     
     func setCurrent(categoryId: Int?, categoryIndex: Int?) {
@@ -20,34 +20,47 @@ final class SelectionManager {
     }
     
     func setCurrent(componentId: Int?) {
-        current.componentId = componentId
+        current.componentInfo = ComponentInfo()
+        current.componentInfo?.componentId = componentId
+        
+        setSelection(current: current)
+    }
+    
+    func setCurrent(colorId: Int?) {
+        current.componentInfo?.corlorId = colorId
         
         setSelection(current: current)
     }
     
     func isSelectedComponent(categoryId: Int, componentId: Int) -> Bool {
-        return selection[categoryId] == componentId
+        return selection[categoryId]?.componentId == componentId
     }
     
     @discardableResult
-    func removeCurrentComponent() -> Int? {
+    func removeCurrentComponent() -> ComponentInfo? {
         guard let categoryId = current.categoryId else { return nil }
         
-        let componentId = selection[categoryId]
-        selection[categoryId] = nil
-        current.componentId = nil
+        let componentInfo = selection[categoryId]
         
-        return componentId
+        selection[categoryId] = nil
+        current.componentInfo = nil
+        
+        return componentInfo
     }
     
     private func setSelection(current: CurrentSelection) {
-        guard let categoryId = current.categoryId, let componentId = current.componentId else { return }
-        selection[categoryId] = componentId
+        guard let categoryId = current.categoryId, let componentInfo = current.componentInfo else { return }
+        selection[categoryId] = componentInfo
     }
 }
 
-final class CurrentSelection {
+struct CurrentSelection {
     var categoryIndex: Int?
     var categoryId: Int?
+    var componentInfo: ComponentInfo?
+}
+
+struct ComponentInfo {
     var componentId: Int?
+    var corlorId: Int?
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/SelectionManager.swift
@@ -19,9 +19,10 @@ final class SelectionManager {
         current.categoryIndex = categoryIndex
     }
     
-    func setCurrent(componentId: Int?) {
+    func setCurrent(componentId: Int?, componentIndexPath: IndexPath? = nil) {
         current.componentInfo = ComponentInfo()
         current.componentInfo?.componentId = componentId
+        current.componentInfo?.componentIndexPath = componentIndexPath
         
         setSelection(current: current)
     }
@@ -62,5 +63,6 @@ struct CurrentSelection {
 
 struct ComponentInfo {
     var componentId: Int?
+    var componentIndexPath: IndexPath?
     var corlorId: Int?
 }

--- a/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
@@ -20,7 +20,7 @@ struct ThumbnailUseCase: RetrieveModelFromServer {
             return nil
         }
         
-        let colorId = currentSelection.componentInfo?.corlorId
+        let colorId = currentSelection.componentInfo?.colorId
         
         let endPoint = EndPoint(path: .thumbnail(categoryId: categoryId, componentId: componentId, colorId: colorId))
         

--- a/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
+++ b/iOS/IDIllust/IDIllust/CustomizeView/UseCase/ThumbnailUseCase.swift
@@ -13,14 +13,16 @@ struct ThumbnailUseCase: RetrieveModelFromServer {
     typealias Model = Thumbnail
     
     @discardableResult
-    func retrieveThumbnail(_ categoryId: Int?, _ componentId: Int?, networkManager: NetworkManageable, failurehandler: @escaping (UseCaseError) -> Void = { _ in }, successHandler: @escaping (Model) -> Void) -> URLSessionDataTask? {
+    func retrieveThumbnail(_ currentSelection: CurrentSelection, networkManager: NetworkManageable, failurehandler: @escaping (UseCaseError) -> Void = { _ in }, successHandler: @escaping (Model) -> Void) -> URLSessionDataTask? {
         
-        guard let categoryId = categoryId, let componentId = componentId else {
+        guard let categoryId = currentSelection.categoryId, let componentId = currentSelection.componentInfo?.componentId else {
             failurehandler(.networkError(.requestError))
             return nil
         }
         
-        let endPoint = EndPoint(path: .thumbnail(categoryId: categoryId, componentId: componentId))
+        let colorId = currentSelection.componentInfo?.corlorId
+        
+        let endPoint = EndPoint(path: .thumbnail(categoryId: categoryId, componentId: componentId, colorId: colorId))
         
         return retrieveModel(from: endPoint, networkManager: networkManager, failurehandler: failurehandler, successHandler: successHandler)
     }

--- a/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
+++ b/iOS/IDIllust/IDIllust/Model/CustomizeView/Component.swift
@@ -24,4 +24,12 @@ struct Component: Decodable {
     let id: Int
     let name: String
     let thumbUrl: String
+    let colors: [Color]
+}
+
+struct Color: Decodable {
+    
+    let id: Int
+    let name: String
+    let url: String
 }

--- a/iOS/IDIllust/IDIllust/Network/EndPoint.swift
+++ b/iOS/IDIllust/IDIllust/Network/EndPoint.swift
@@ -31,7 +31,7 @@ struct EndPoint {
         case entry
         case categories
         case components(categoryId: Int)
-        case thumbnail(categoryId: Int, componentId: Int)
+        case thumbnail(categoryId: Int, componentId: Int, colorId: Int? = nil)
         
         var description: String {
             switch self {
@@ -41,8 +41,10 @@ struct EndPoint {
                 return "/api/categories"
             case .components(let categoryId):
                 return "/api/categories/\(categoryId)/components"
-            case .thumbnail(let categoryId, let componentId):
-                return "/api/categories/\(categoryId)/components/\(componentId)"
+            case .thumbnail(let categoryId, let componentId, let colorId):
+                guard let colorId = colorId else { return "/api/categories/\(categoryId)/components/\(componentId)" }
+                
+                return "/api/categories/\(categoryId)/components/\(componentId)/colors/\(colorId)"
             }
         }
     }

--- a/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
@@ -25,50 +25,39 @@ final class CategoryComponentManagerTests: XCTestCase {
         colors = [Color(id: 1, name: "color", url: "url")]
         component = Component(id: 1, name: "component", thumbUrl: "url", colors: colors)
         components = Components(models: [component])
+        
+        categoryComponentManager.insert(categories: categories)
+        categoryComponentManager.insert(components: components, by: category.id)
     }
     
     func testInsertCategories() {
-        categoryComponentManager.insert(categories: categories)
         let inserted = categoryComponentManager.categories
         XCTAssertEqual(categories, inserted)
     }
     
     func testInsertComponents() {
-        categoryComponentManager.insert(categories: categories)
-        categoryComponentManager.insert(components: components, by: category.id)
         let inserted = categoryComponentManager.components(of: category.id)
         XCTAssertEqual(components, inserted)
     }
     
     func testCategory() {
-        categoryComponentManager.insert(categories: categories)
         let inserted = categoryComponentManager.category(of: 0)
         XCTAssertEqual(category, inserted)
     }
     
     func testCategoryCount() {
-        XCTAssertNil(categoryComponentManager.categoryCount)
-        categoryComponentManager.insert(categories: categories)
         XCTAssertEqual(categoryComponentManager.categoryCount, 1)
     }
     
     func testComponentsCount() {
-        XCTAssertNil(categoryComponentManager.componentsCount(of: category.id))
-        categoryComponentManager.insert(categories: categories)
-        categoryComponentManager.insert(components: components, by: category.id)
         XCTAssertEqual(categoryComponentManager.componentsCount(of: category.id), 1)
     }
     
     func testGetComponent() {
-        XCTAssertNil(categoryComponentManager.component(category.id, 0))
-        categoryComponentManager.insert(categories: categories)
-        categoryComponentManager.insert(components: components, by: category.id)
         XCTAssertEqual(categoryComponentManager.component(category.id, 0), component)
     }
     
     func testIsExistComponents() {
-        categoryComponentManager.insert(categories: categories)
-        categoryComponentManager.insert(components: components, by: category.id)
         XCTAssertTrue(categoryComponentManager.isExistComponents(with: category.id))
         XCTAssertFalse(categoryComponentManager.isExistComponents(with: -1))
     }

--- a/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/CategoryComponentManagerTests.swift
@@ -16,12 +16,14 @@ final class CategoryComponentManagerTests: XCTestCase {
     private var categories: Categories!
     private var component: Component!
     private var components: Components!
+    private var colors: [Color]!
 
     override func setUpWithError() throws {
         categoryComponentManager = CategoryComponentManager()
         category = IDIllust.Category(id: 1, name: "category", url: "url")
         categories = Categories(models: [category])
-        component = Component(id: 1, name: "component", thumbUrl: "url")
+        colors = [Color(id: 1, name: "color", url: "url")]
+        component = Component(id: 1, name: "component", thumbUrl: "url", colors: colors)
         components = Components(models: [component])
     }
     

--- a/iOS/IDIllust/IDIllustTests/EndPointTests.swift
+++ b/iOS/IDIllust/IDIllustTests/EndPointTests.swift
@@ -29,5 +29,8 @@ final class EndPointTests: XCTestCase {
     func testThumbnailEndPointValid() {
         let thumbnail = EndPoint(path: .thumbnail(categoryId: 1, componentId: 1))
         XCTAssertEqual(thumbnail.url, URL(string: "http://3.34.77.7/api/categories/1/components/1"))
+        
+        let thumbnailWithColorId = EndPoint(path: .thumbnail(categoryId: 1, componentId: 1, colorId: 2))
+        XCTAssertEqual(thumbnailWithColorId.url, URL(string: "http://3.34.77.7/api/categories/1/components/1/colors/2"))
     }
 }

--- a/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
+++ b/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
@@ -16,6 +16,6 @@ extension CurrentSelection: Equatable {
 
 extension ComponentInfo: Equatable {
     public static func == (lhs: ComponentInfo, rhs: ComponentInfo) -> Bool {
-        return lhs.componentId == rhs.componentId && lhs.corlorId == rhs.corlorId
+        return lhs.componentId == rhs.componentId && lhs.componentIndexPath == rhs.componentIndexPath && lhs.corlorId == rhs.corlorId
     }
 }

--- a/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
+++ b/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
@@ -10,6 +10,12 @@
 
 extension CurrentSelection: Equatable {
     public static func == (lhs: CurrentSelection, rhs: CurrentSelection) -> Bool {
-        return lhs.categoryIndex == rhs.categoryIndex && lhs.categoryId == rhs.categoryId && lhs.componentId == rhs.componentId
+        return lhs.categoryIndex == rhs.categoryIndex && lhs.categoryId == rhs.categoryId && lhs.componentInfo == rhs.componentInfo
+    }
+}
+
+extension ComponentInfo: Equatable {
+    public static func == (lhs: ComponentInfo, rhs: ComponentInfo) -> Bool {
+        return lhs.componentId == rhs.componentId && lhs.corlorId == rhs.corlorId
     }
 }

--- a/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
+++ b/iOS/IDIllust/IDIllustTests/Extension/CurrentSelection.swift
@@ -16,6 +16,6 @@ extension CurrentSelection: Equatable {
 
 extension ComponentInfo: Equatable {
     public static func == (lhs: ComponentInfo, rhs: ComponentInfo) -> Bool {
-        return lhs.componentId == rhs.componentId && lhs.componentIndexPath == rhs.componentIndexPath && lhs.corlorId == rhs.corlorId
+        return lhs.componentId == rhs.componentId && lhs.componentIndexPath == rhs.componentIndexPath && lhs.colorId == rhs.colorId
     }
 }

--- a/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
@@ -14,7 +14,9 @@ class SelectionManagerTests: XCTestCase {
     private var selectionManager: SelectionManager!
     private var currentSelection: CurrentSelection!
     private let categoryId = 0
+    private var componentInfo = ComponentInfo()
     private let componentId = 1
+    private let colorId = 2
     
     override func setUpWithError() throws {
         selectionManager = SelectionManager()
@@ -30,17 +32,35 @@ class SelectionManagerTests: XCTestCase {
     }
     
     func testSetCurrentComponentId() {
-        currentSelection.componentId = componentId
-        selectionManager.setCurrent(componentId: componentId)
+        componentInfo.componentId = componentId
+        currentSelection.componentInfo = componentInfo
+        selectionManager.setCurrent(componentId: componentInfo.componentId)
         
         XCTAssertEqual(selectionManager.current, currentSelection)
     }
     
+    func testSetCurrentColorId() {
+        componentInfo.componentId = componentId
+        componentInfo.corlorId = colorId
+        
+        selectionManager.setCurrent(componentId: componentId)
+        selectionManager.setCurrent(colorId: colorId)
+        
+        XCTAssertEqual(selectionManager.current.componentInfo, componentInfo)
+        
+        componentInfo.corlorId = 3
+        selectionManager.setCurrent(colorId: 3)
+        
+        XCTAssertEqual(selectionManager.current.componentInfo, componentInfo)
+    }
+    
     func testSelectionValid() {
+        componentInfo.componentId = componentId
+        
         selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
         selectionManager.setCurrent(componentId: componentId)
         
-        XCTAssertEqual(selectionManager.selection, [categoryId: componentId])
+        XCTAssertEqual(selectionManager.selection, [categoryId: componentInfo])
     }
     
     func testIsSelectedComponent() {
@@ -56,10 +76,14 @@ class SelectionManagerTests: XCTestCase {
         
         selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
         selectionManager.setCurrent(componentId: componentId)
+        selectionManager.setCurrent(colorId: colorId)
         
-        XCTAssertEqual(selectionManager.removeCurrentComponent(), componentId)
+        componentInfo.componentId = componentId
+        componentInfo.corlorId = colorId
         
-        XCTAssertNil(selectionManager.current.componentId)
+        XCTAssertEqual(selectionManager.removeCurrentComponent(), componentInfo)
+        
+        XCTAssertNil(selectionManager.current.componentInfo)
         XCTAssertNil(selectionManager.selection[categoryId])
     }
 }

--- a/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
@@ -22,24 +22,28 @@ class SelectionManagerTests: XCTestCase {
     override func setUpWithError() throws {
         selectionManager = SelectionManager()
         currentSelection = CurrentSelection()
+        
+        componentInfo.componentId = componentId
+        componentInfo.colorId = colorId
+        
+        currentSelection.categoryId = categoryId
+        currentSelection.categoryIndex = 0
+        currentSelection.componentInfo = componentInfo
+        
+        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
+        selectionManager.setCurrent(componentId: componentInfo.componentId)
+        selectionManager.setCurrent(colorId: componentInfo.colorId)
     }
     
     func testSetCurrentCategoryIdCategoryIndex() {
-        currentSelection.categoryId = categoryId
-        currentSelection.categoryIndex = 0
-        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
-        
         XCTAssertEqual(selectionManager.current, currentSelection)
     }
     
     func testSetCurrentComponentId() {
-        componentInfo.componentId = componentId
-        currentSelection.componentInfo = componentInfo
-        selectionManager.setCurrent(componentId: componentInfo.componentId)
-        
         XCTAssertEqual(selectionManager.current, currentSelection)
         
         selectionManager.removeCurrentComponent()
+        componentInfo.colorId = nil
         
         componentInfo.componentId = componentId
         componentInfo.componentIndexPath = componentIndexPath
@@ -50,46 +54,33 @@ class SelectionManagerTests: XCTestCase {
     }
     
     func testSetCurrentColorId() {
-        componentInfo.componentId = componentId
-        componentInfo.corlorId = colorId
-        
-        selectionManager.setCurrent(componentId: componentId)
-        selectionManager.setCurrent(colorId: colorId)
-        
+        XCTAssertEqual(selectionManager.colorSelectionForEachComponent[componentId], colorId)
         XCTAssertEqual(selectionManager.current.componentInfo, componentInfo)
         
-        componentInfo.corlorId = 3
+        componentInfo.colorId = 3
         selectionManager.setCurrent(colorId: 3)
         
         XCTAssertEqual(selectionManager.current.componentInfo, componentInfo)
     }
     
     func testSelectionValid() {
-        componentInfo.componentId = componentId
-        
-        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
-        selectionManager.setCurrent(componentId: componentId)
-        
         XCTAssertEqual(selectionManager.selection, [categoryId: componentInfo])
     }
     
     func testIsSelectedComponent() {
-        selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
-        selectionManager.setCurrent(componentId: componentId)
-        
         XCTAssertTrue(selectionManager.isSelectedComponent(categoryId: categoryId, componentId: componentId))
         XCTAssertFalse(selectionManager.isSelectedComponent(categoryId: categoryId, componentId: 9))
     }
     
     func testRemoveCurrentComponent() {
-        XCTAssertNil(selectionManager.removeCurrentComponent())
+        XCTAssertEqual(selectionManager.removeCurrentComponent(), componentInfo)
         
         selectionManager.setCurrent(categoryId: categoryId, categoryIndex: 0)
         selectionManager.setCurrent(componentId: componentId)
         selectionManager.setCurrent(colorId: colorId)
         
         componentInfo.componentId = componentId
-        componentInfo.corlorId = colorId
+        componentInfo.colorId = colorId
         
         XCTAssertEqual(selectionManager.removeCurrentComponent(), componentInfo)
         

--- a/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
+++ b/iOS/IDIllust/IDIllustTests/SelectionManagerTests.swift
@@ -16,6 +16,7 @@ class SelectionManagerTests: XCTestCase {
     private let categoryId = 0
     private var componentInfo = ComponentInfo()
     private let componentId = 1
+    private let componentIndexPath = IndexPath(item: 0, section: 0)
     private let colorId = 2
     
     override func setUpWithError() throws {
@@ -35,6 +36,15 @@ class SelectionManagerTests: XCTestCase {
         componentInfo.componentId = componentId
         currentSelection.componentInfo = componentInfo
         selectionManager.setCurrent(componentId: componentInfo.componentId)
+        
+        XCTAssertEqual(selectionManager.current, currentSelection)
+        
+        selectionManager.removeCurrentComponent()
+        
+        componentInfo.componentId = componentId
+        componentInfo.componentIndexPath = componentIndexPath
+        currentSelection.componentInfo = componentInfo
+        selectionManager.setCurrent(componentId: componentId, componentIndexPath: componentIndexPath)
         
         XCTAssertEqual(selectionManager.current, currentSelection)
     }

--- a/iOS/IDIllust/IDIllustTests/UseCase/ComponentsUseCaseTests.swift
+++ b/iOS/IDIllust/IDIllustTests/UseCase/ComponentsUseCaseTests.swift
@@ -15,7 +15,7 @@ class ComponentsUseCaseTests: XCTestCase {
     private var model: Components!
 
     override func setUpWithError() throws {
-        let component = IDIllust.Component(id: 1, name: "test", thumbUrl: "url")
+        let component = IDIllust.Component(id: 1, name: "test", thumbUrl: "url", colors: [Color(id: 1, name: "test", url: "url")])
         model = Components(models: [component])
     }
     

--- a/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
+++ b/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
@@ -20,11 +20,23 @@ class ThumbnailUseCaseTests: XCTestCase {
     
     func testSuccess() {
         mockNetworkManager = MockSuccessNetworkManager(model: model)
-        
-        ThumbnailUseCase().retrieveThumbnail(0, 0,
+        let componentInfo = ComponentInfo(componentId: 0, componentIndexPath: IndexPath(item: 0, section: 0), corlorId: 3)
+        let currentSelection = CurrentSelection(categoryIndex: 1, categoryId: 2, componentInfo: componentInfo)
+        ThumbnailUseCase().retrieveThumbnail(currentSelection, 
                                              networkManager: mockNetworkManager,
                                              successHandler: { model in
                                                 XCTAssertEqual(model, self.model)
                                              })
+    }
+    
+    func testNetworkError() {
+        let currentSelection = CurrentSelection()
+        mockNetworkManager = MockSuccessNetworkManager(model: model)
+        ThumbnailUseCase().retrieveThumbnail(currentSelection,
+                                             networkManager: mockNetworkManager,
+                                             failurehandler: { error in
+                                                XCTAssertEqual(error, UseCaseError.networkError(.requestError))
+                                             },
+                                             successHandler: { _ in })
     }
 }

--- a/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
+++ b/iOS/IDIllust/IDIllustTests/UseCase/ThumbnailUseCaseTests.swift
@@ -20,7 +20,7 @@ class ThumbnailUseCaseTests: XCTestCase {
     
     func testSuccess() {
         mockNetworkManager = MockSuccessNetworkManager(model: model)
-        let componentInfo = ComponentInfo(componentId: 0, componentIndexPath: IndexPath(item: 0, section: 0), corlorId: 3)
+        let componentInfo = ComponentInfo(componentId: 0, componentIndexPath: IndexPath(item: 0, section: 0), colorId: 3)
         let currentSelection = CurrentSelection(categoryIndex: 1, categoryId: 2, componentInfo: componentInfo)
         ThumbnailUseCase().retrieveThumbnail(currentSelection, 
                                              networkManager: mockNetworkManager,


### PR DESCRIPTION
# 주요 기능
## ColorSelectCollectionView에 colorModel 전달
- component에 대해 색상을 선택할 수 있도록 LongPress 이벤트가 발생한 포인트에 해당하는 모델의 colorList를 ColorSelectViewController에 넘겼습니다.
- ColorSelectViewController의 color 프로퍼티가 변경되면 ColorSelectCollectionView를 reload 해줬습니다.

## ColorSelectView frame 조정
- ColorSelectView는 ColorSelectViewController의 view를 보여주는 containerView입니다. LongPressChanged 이벤트에서 전달되는 x좌표에 따라 color 선택을 할 수 있도록 합니다. 
이 기능을 보다 가시적으로 제공하기 위해 ColorSelectView의 크기를 ColorSelectCollectionView의 크기와 같게 해야 했습니다(한번에 모든 선택지를 보여주기 위해). 따라서 UICollectionView의 reloadData() 메소드가 완료되고 난 후 크기를 조정해야 합니다.
- 하지만 UICollectionView의 reloadData() 메소드는 비동기 메소드이고, reloadData() 메소드가 끝나는 시점을 알 수 없었습니다. 이 시점을 알아내기 위해 DisPatchQueue.main.sync 내부에서 reloadData()를 해주려 했으나, mainQueue가 mainQueue를 기다리는 deadlock 현상이 발생했습니다.
- 따라서 아래와 같이 serialQueue를 하나 만들어 내부에서 작업을 수행하게 했습니다. reloadQueue가 DispatchQueue 내부에서 일어나는 작업을 기다리기 때문에 deadlock이 발생하지 않았습니다. 또한 serialQueue는 한번에 하나의 작업만 처리할 수 있기 때문에 queue에 들어온 순서대로 작업의 순서를 보장할 수 있었습니다.
``` swift
private let reloadQueue = DispatchQueue(label: "reloadQueue")
var colors: [Color]? {
    didSet {
        reloadQueue.async {
            DispatchQueue.main.sync { [weak self] in
                self?.colorSelectCollectionView.reloadData()
            }
        }
       
        reloadQueue.async { [weak self] in
            /// 완료 시점 작업
        }
    }
}
```

## 전달된 colorId를 바탕으로 thumbnail 이미지 받아오기
- delegate 패턴을 활용해 작업을 처리했습니다. Notification을 사용하지 않은 이유는 colorId 선택은 component 단일에 대한 작업이기 때문에 1:1 작업이라고 생각했습니다. 따라서 1:N을 고려할 필요가 없다고 생각했기 때문입니다.
- 이미 color를 선택한 component에 대해 다시 color를 선택할 경우 원래 선택을 보여주기 위해 selectionManager에서 componentId와 colorId를 매핑하는 딕셔너리를 가지고 있게 했습니다.

# 기타 변경 사항
- 일부 모델이 class로 선언되어있는 것을 struct로 변경하였습니다. 이는 원치않은 모델 변경이 일어나는 것을 방지하기 위함입니다.
- unit test 코드에서 중복되는 코드를 제거했습니다.

![colorSelectExample](https://user-images.githubusercontent.com/37682858/98441777-d41b0c80-2143-11eb-99be-8f7ea8a00e46.gif)
